### PR TITLE
BatteryMonitor: fix LiPo SoC curve and voltage recalibration

### DIFF
--- a/src/BatteryMonitor/BatteryMonitor.cpp
+++ b/src/BatteryMonitor/BatteryMonitor.cpp
@@ -95,13 +95,18 @@ uint8_t BatteryMonitor::estimateSoCFromVoltageLiPo(uint16_t batteryMilliVolts) c
         uint8_t soc;
     };
 
+    // Real LiPo discharge curve: voltage drops quickly from 4.20V to ~4.00V
+    // (surface charge effect) but little actual capacity is consumed in that region.
+    // The main capacity plateau spans 4.00V down to ~3.40V, then drops steeply.
     const VoltToSoC curve[] = {
-        {4200, 100}, {4150, 95}, {4100, 90}, {4050, 85},
-        {4000, 80}, {3950, 75}, {3900, 70}, {3850, 65},
-        {3800, 60}, {3750, 55}, {3700, 50}, {3650, 45},
-        {3600, 40}, {3550, 35}, {3500, 30}, {3450, 25},
-        {3400, 20}, {3350, 15}, {3300, 10}, {3250, 5},
-        {3200, 2}, {3100, 0}
+        {4200, 100}, {4175, 99}, {4150, 97}, {4125, 94},
+        {4100, 91},  {4075, 88}, {4050, 87},
+        {4000, 85},  // plateau begins ~4.00V; most capacity lives below this
+        {3950, 79},  {3900, 72}, {3850, 64},
+        {3800, 56},  {3750, 48}, {3700, 40},
+        {3650, 32},  {3600, 24}, {3550, 17},
+        {3500, 11},  {3450, 6},  {3400, 3},
+        {3300, 1},   {3200, 0}
     };
 
     const int curveSize = sizeof(curve) / sizeof(VoltToSoC);

--- a/src/BatteryMonitor/BatteryMonitor.cpp
+++ b/src/BatteryMonitor/BatteryMonitor.cpp
@@ -190,10 +190,16 @@ void BatteryMonitor::recalibrateFromVoltage() {
     uint32_t voltageBasedRemaining = remainingMahFromScaledSoc(scaledSoc);
 
     if (isCurrentAvailable()) {
-        // Current available: smooth recalibration 90% Coulomb + 10% voltage-based
-        remainingMilliAh = (remainingMilliAh * 9 + voltageBasedRemaining) / 10;
+        // Current available: voltage recalibration is only used as a downward correction.
+        // When the motor stops, battery voltage recovers (IR drop disappears), making
+        // voltage-based SoC appear higher than the true discharge state. Pulling
+        // remainingMilliAh upward in that case would corrupt the coulomb count, so
+        // we only nudge downward — trusting coulomb counting when voltage looks better.
+        if (voltageBasedRemaining < remainingMilliAh) {
+            remainingMilliAh = (remainingMilliAh * 9 + voltageBasedRemaining) / 10;
+        }
     } else {
-        // No current source available: voltage-only
+        // No current source available: voltage is all we have.
         remainingMilliAh = voltageBasedRemaining;
     }
 


### PR DESCRIPTION
## Summary

- **Curva de tensão→SoC corrigida** para refletir o perfil real de descarga LiPo: a queda de 4.20V a 4.00V é um efeito de carga de superfície e representa apenas ~15% da capacidade real. A curva anterior tratava essa região de forma linear (100→80%), superestimando o consumo no topo da carga.

- **Recalibração por tensão agora só atua para baixo**: quando o motor para, a tensão da bateria se recupera (eliminação do IR drop), fazendo a estimativa por tensão parecer mais otimista que o estado real. O código anterior aplicava o blend `90% coulomb + 10% tensão` sem restrição, corrompendo o contador coulomb a cada parada. Agora a tensão só é usada para corrigir para baixo — o coulomb count é mantido quando a tensão indica mais carga.

## Test plan

- [x] Build `lolin_c3_mini_hobbywing` — SUCCESS
- [x] Build `lolin_c3_mini_tmotor` — SUCCESS
- [x] Build `lolin_c3_mini_xag` — SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)