### PR TITLE
fix: FreeRTOS concurrency — volatile throttleArmed, BMS notify mutex, Settings mutex

### DIFF
--- a/src/DalyBms/DalyBms.cpp
+++ b/src/DalyBms/DalyBms.cpp
@@ -196,12 +196,14 @@ uint16_t DalyBms::getCellDeltaMilliVolts() const {
 }
 
 void DalyBms::onNotify(uint8_t* data, size_t len) {
+    xSemaphoreTake(stateMutex_, portMAX_DELAY);
     if (rxLen_ + len > RX_BUFFER_SIZE) {
         rxLen_ = 0;
         DEBUG_PRINTLN("[Daly] RX buffer overflow, discarding");
     }
     memcpy(rxBuffer_ + rxLen_, data, len);
     rxLen_ += len;
+    xSemaphoreGive(stateMutex_);
 }
 
 void DalyBms::resetConnection() {
@@ -309,14 +311,18 @@ void DalyBms::sendStatusRequest() {
 }
 
 void DalyBms::processRxBuffer() {
-    while (rxLen_ >= 5) {
+    xSemaphoreTake(stateMutex_, portMAX_DELAY);
+
+    bool done = false;
+    while (!done && rxLen_ >= 5) {
         if (rxBuffer_[0] != 0xD2) {
             size_t skip = 0;
             while (skip < rxLen_ && rxBuffer_[skip] != 0xD2) skip++;
             if (skip >= rxLen_) {
                 DEBUG_PRINTLN("[Daly] Discarding RX buffer while searching for 0xD2");
                 rxLen_ = 0;
-                return;
+                done = true;
+                continue;
             }
             DEBUG_PRINT("[Daly] Resyncing RX buffer, skipped bytes: ");
             DEBUG_PRINTLN(skip);
@@ -331,10 +337,12 @@ void DalyBms::processRxBuffer() {
             DEBUG_PRINT("[Daly] Invalid frame length: ");
             DEBUG_PRINTLN(frameLen);
             rxLen_ = 0;
-            return;
+            done = true;
+            continue;
         }
         if (rxLen_ < frameLen) {
-            return;
+            done = true;
+            continue;
         }
 
         DEBUG_PRINT("[Daly] RX: ");
@@ -357,6 +365,8 @@ void DalyBms::processRxBuffer() {
         memmove(rxBuffer_, rxBuffer_ + 1, rxLen_ - 1);
         rxLen_ -= 1;
     }
+
+    xSemaphoreGive(stateMutex_);
 }
 
 void DalyBms::parseStatusFrame(const uint8_t* frame, size_t frameLen) {

--- a/src/JbdBms/JbdBms.cpp
+++ b/src/JbdBms/JbdBms.cpp
@@ -313,6 +313,7 @@ void JbdBms::update() {
 // onNotify — called by BLE stack ISR-like callback
 // ---------------------------------------------------------------------------
 void JbdBms::onNotify(uint8_t* data, size_t len) {
+    xSemaphoreTake(stateMutex_, portMAX_DELAY);
     if (rxLen_ + len > JBD_RX_BUFFER_SIZE) {
         // Overflow: discard buffer to avoid garbage accumulation
         DEBUG_PRINTLN("[JBD] RX buffer overflow, discarding");
@@ -320,6 +321,7 @@ void JbdBms::onNotify(uint8_t* data, size_t len) {
     }
     memcpy(rxBuffer_ + rxLen_, data, len);
     rxLen_ += len;
+    xSemaphoreGive(stateMutex_);
 }
 
 // ---------------------------------------------------------------------------
@@ -334,7 +336,10 @@ void JbdBms::onNotify(uint8_t* data, size_t len) {
 // Checksum (reception): 0x10000 - (STATUS + LEN + DATA[...])
 // ---------------------------------------------------------------------------
 void JbdBms::processRxBuffer() {
-    while (rxLen_ > 0) {
+    xSemaphoreTake(stateMutex_, portMAX_DELAY);
+
+    bool done = false;
+    while (!done && rxLen_ > 0) {
 
         // --- Discard FF AA wrapper if present at start ---
         if (rxLen_ >= 2 && rxBuffer_[0] == 0xFF && rxBuffer_[1] == 0xAA) {
@@ -347,14 +352,14 @@ void JbdBms::processRxBuffer() {
         if (rxBuffer_[0] != JBD_FRAME_START) {
             size_t skip = 0;
             while (skip < rxLen_ && rxBuffer_[skip] != JBD_FRAME_START) skip++;
-            if (skip >= rxLen_) { rxLen_ = 0; return; }
+            if (skip >= rxLen_) { rxLen_ = 0; done = true; continue; }
             memmove(rxBuffer_, rxBuffer_ + skip, rxLen_ - skip);
             rxLen_ -= skip;
             continue;
         }
 
         // --- Need at least 4 bytes to read LEN ---
-        if (rxLen_ < 4) return;
+        if (rxLen_ < 4) { done = true; continue; }
 
         uint8_t reg     = rxBuffer_[1];
         uint8_t status  = rxBuffer_[2];
@@ -364,7 +369,7 @@ void JbdBms::processRxBuffer() {
         size_t frameLen = (size_t)dataLen + 7;
 
         // Wait for full frame to arrive (may come in multiple BLE packets)
-        if (rxLen_ < frameLen) return;
+        if (rxLen_ < frameLen) { done = true; continue; }
 
         // --- Verify end byte 0x77 ---
         if (rxBuffer_[frameLen - 1] != JBD_FRAME_END) {
@@ -417,6 +422,8 @@ void JbdBms::processRxBuffer() {
         memmove(rxBuffer_, rxBuffer_ + frameLen, rxLen_ - frameLen);
         rxLen_ -= frameLen;
     }
+
+    xSemaphoreGive(stateMutex_);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/Settings/Settings.cpp
+++ b/src/Settings/Settings.cpp
@@ -58,9 +58,11 @@ Settings::Settings() {
     wifiAutoDisableAfterCalibration = true;
     bmsType = BmsTypeNone;
     throttleCurveGamma = 1.0f;
+    mutex_ = nullptr;
 }
 
 void Settings::init() {
+    mutex_ = xSemaphoreCreateMutex();
     preferences.begin("flyctrl", false);
     load();
 }
@@ -143,6 +145,10 @@ void Settings::load() {
 }
 
 void Settings::save() {
+    // Protect against concurrent calls from WiFi task and main loop.
+    // NVS writes are slow (~ms each); holding the mutex ensures the main loop
+    // never reads a partially-updated snapshot of member variables while we write.
+    if (mutex_) xSemaphoreTake(mutex_, portMAX_DELAY);
     preferences.putUInt("batCap", batteryCapacityMah);
     preferences.putUInt("batMinV", batteryMinVoltage);
     preferences.putUInt("batMaxV", batteryMaxVoltage);
@@ -155,6 +161,7 @@ void Settings::save() {
     preferences.putUChar("bmsType", bmsType);
     preferences.putString("bmsMac", bmsMac);
     preferences.putFloat("thrCurveG", throttleCurveGamma);
+    if (mutex_) xSemaphoreGive(mutex_);
 }
 
 uint16_t Settings::getBatteryCapacityMah() const {
@@ -285,15 +292,21 @@ void Settings::setBmsType(uint8_t type) {
 }
 
 String Settings::getBmsMac() const {
-    return bmsMac;
+    // String is a heap-allocated object — protect against concurrent access from WiFi task.
+    if (mutex_) xSemaphoreTake(mutex_, portMAX_DELAY);
+    String copy = bmsMac;
+    if (mutex_) xSemaphoreGive(mutex_);
+    return copy;
 }
 
 void Settings::setBmsMac(const char* mac) {
+    if (mutex_) xSemaphoreTake(mutex_, portMAX_DELAY);
     if (mac != nullptr) {
         bmsMac = String(mac);
     } else {
         bmsMac = "";
     }
+    if (mutex_) xSemaphoreGive(mutex_);
 }
 
 uint8_t Settings::getDefaultBmsType() const {

--- a/src/Settings/Settings.h
+++ b/src/Settings/Settings.h
@@ -3,6 +3,8 @@
 
 #include <Arduino.h>
 #include <Preferences.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 enum BmsType : uint8_t {
     BmsTypeNone = 0,
@@ -59,6 +61,7 @@ public:
 
 private:
     Preferences preferences;
+    SemaphoreHandle_t mutex_;
 
     // Default values
     uint16_t getDefaultBatteryCapacity() const;

--- a/src/Throttle/Throttle.h
+++ b/src/Throttle/Throttle.h
@@ -31,7 +31,7 @@ class Throttle {
         int pinValueFiltered;
         unsigned long lastThrottleRead;
 
-        bool throttleArmed;
+        volatile bool throttleArmed;
 
         bool calibrated;
         unsigned int calibratingStep;


### PR DESCRIPTION
## Problema

Três pontos de corrupção de estado entre tasks FreeRTOS:

1. **`throttleArmed`** — lido pelas tasks de BLE (JBD/Daly) enquanto o loop principal escreve. Sem `volatile`, o compilador pode cachear o valor em registrador e a task BLE nunca vê a mudança.

2. **`JbdBms` / `DalyBms` `onNotify()`** — chamado pela BLE stack em task separada; escreve em `rxBuffer_` / `rxLen_` sem segurar `stateMutex_`. O loop principal chama `processRxBuffer()` no mesmo momento, causando race condition na leitura e modificação do buffer.

3. **`Settings::save()`** — chamado pelo handler AsyncWebServer (task WiFi) enquanto o loop principal lê os campos. Strings (`bmsMac`) são objetos heap-alocados — acesso concorrente sem lock pode causar use-after-free.

## Solução

- `Throttle.h`: `volatile bool throttleArmed`
- `JbdBms.cpp`: `stateMutex_` (já existia) adquirido em `onNotify()` e em `processRxBuffer()` — substituídos `return` internos por flag `done` para garantir `xSemaphoreGive` em todos os caminhos de saída
- `DalyBms.cpp`: mesmo padrão
- `Settings.h/.cpp`: novo `SemaphoreHandle_t mutex_`, criado em `init()` (não no construtor — FreeRTOS ainda não ativo); protege `save()`, `getBmsMac()` e `setBmsMac()`

## Verificação

- [x] Build `lolin_c3_mini_hobbywing` — SUCCESS
- [x] Build `lolin_c3_mini_tmotor` — SUCCESS
- [x] Build `lolin_c3_mini_xag` — SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)