### PR TITLE
fix: ADS1115 init check, Serial to DEBUG macros in TWAI, battery fallback 0->50%

### DIFF
--- a/src/Power/Power.cpp
+++ b/src/Power/Power.cpp
@@ -149,7 +149,9 @@ unsigned int Power::calcPower() {
 
 unsigned int Power::calcBatteryLimit() {
     if (!getBoardConfig().useBatteryLimit) return 100;
-    if (!telemetry.hasData()) return 0;
+    // Return conservative 50% when telemetry is not yet available — avoids a
+    // full motor cutoff at startup before the ESC sends its first CAN frame.
+    if (!telemetry.hasData()) return 50;
 
     uint16_t batteryMilliVolts = telemetry.getBatteryVoltageMilliVolts();
     const unsigned int STEP_DECREASE = 5;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,9 @@ void setup()
 
   // Initialize ADS1115 for all builds (throttle, motor temp; XAG uses Ch2/Ch3 for ESC temp and battery; Tmotor uses Ch3 for battery)
   extern ADS1115 ads1115;
-  ads1115.begin(I2C_SDA_PIN, I2C_SCL_PIN);
+  if (!ads1115.begin(I2C_SDA_PIN, I2C_SCL_PIN)) {
+    DEBUG_PRINTLN("[Main] WARNING: ADS1115 init failed — throttle and temp readings unavailable");
+  }
 
   xctod.init();
   bluetoothBms.init();
@@ -71,18 +73,18 @@ void setup()
 
   esp_err_t install_result = twai_driver_install(&g_config, &t_config, &f_config);
   if (install_result != ESP_OK) {
-    Serial.print("[Main] ERROR: Failed to install TWAI driver - Error: ");
-    Serial.println(install_result);
+    DEBUG_PRINT("[Main] ERROR: Failed to install TWAI driver - Error: ");
+    DEBUG_PRINTLN(install_result);
   } else {
-    Serial.println("[Main] TWAI driver installed successfully");
+    DEBUG_PRINTLN("[Main] TWAI driver installed successfully");
   }
 
   esp_err_t start_result = twai_start();
   if (start_result != ESP_OK) {
-    Serial.print("[Main] ERROR: Failed to start TWAI driver - Error: ");
-    Serial.println(start_result);
+    DEBUG_PRINT("[Main] ERROR: Failed to start TWAI driver - Error: ");
+    DEBUG_PRINTLN(start_result);
   } else {
-    Serial.println("[Main] TWAI driver started successfully");
+    DEBUG_PRINTLN("[Main] TWAI driver started successfully");
 
     // Wait a bit for driver to be ready
     delay(50);
@@ -90,10 +92,10 @@ void setup()
     // Check driver status (using only standard fields)
     twai_status_info_t status_info;
     twai_get_status_info(&status_info);
-    Serial.print("[Main] TWAI Status - TX Errors: ");
-    Serial.print(status_info.tx_error_counter);
-    Serial.print(", RX Errors: ");
-    Serial.println(status_info.rx_error_counter);
+    DEBUG_PRINT("[Main] TWAI Status - TX Errors: ");
+    DEBUG_PRINT(status_info.tx_error_counter);
+    DEBUG_PRINT(", RX Errors: ");
+    DEBUG_PRINTLN(status_info.rx_error_counter);
   }
 
   // Hobbywing-specific initialization


### PR DESCRIPTION
## Changes

### B1 — ADS1115 init check (`main.cpp`)
`ads1115.begin()` returns `bool` but the return value was silently discarded. Added a `DEBUG_PRINTLN` warning when the I2C device is not found. The system continues running (sensor may be absent in some hardware variants) but the failure is now visible in debug builds.

### B2 — `Serial.*` → `DEBUG_*` in TWAI init block (`main.cpp`)
TWAI init diagnostics were using `Serial.print/println` directly. In production builds Serial output is not used, and these calls add unnecessary overhead. Replaced with `DEBUG_PRINT`/`DEBUG_PRINTLN` macros (defined in `config.h`) which compile to nothing unless `-D DEBUG=1` is set.

### B3 — Battery limit fallback `0` → `50%` (`Power.cpp`)
`calcBatteryLimit()` returned `0` (full cutoff) when `telemetry.hasData()` was false — this happens at startup before the ESC sends its first CAN frame. A full cutoff at arm time is unsafe. Changed to `50%` as a conservative but non-zero fallback while waiting for the first telemetry frame.

## Verification

- [x] Build `lolin_c3_mini_hobbywing` — SUCCESS
- [x] Build `lolin_c3_mini_tmotor` — SUCCESS
- [x] Build `lolin_c3_mini_xag` — SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)