### PR TITLE
fix: watchdog timer, BMS facade in Xctod, battery capacity propagation

### DIFF
--- a/src/WebServer/ControllerWebServer.cpp
+++ b/src/WebServer/ControllerWebServer.cpp
@@ -2,6 +2,7 @@
 #include <ESPmDNS.h>
 #include "../config.h"
 #include "../Settings/Settings.h"
+#include "../BatteryMonitor/BatteryMonitor.h"
 #include "../BoardConfig.h"
 #include "../Telemetry/TelemetryAvailability.h"
 #include <Update.h>
@@ -273,6 +274,9 @@ void ControllerWebServer::startAP() {
             settings.setPowerControlEnabled(doc["powerControlEnabled"].as<bool>());
             settings.setThrottleCurveGamma(gamma);
             settings.save();
+            // Keep the in-memory BatteryMonitor in sync with the new capacity
+            // setting — without this, Coulomb counting uses the old value until reboot.
+            batteryMonitor.setCapacity(settings.getBatteryCapacityMah());
 
             request->send(200, "text/plain", "Success: Power configuration saved");
         },

--- a/src/Xctod/Xctod.cpp
+++ b/src/Xctod/Xctod.cpp
@@ -7,7 +7,7 @@
 #include "../Temperature/Temperature.h"
 #include "../BatteryMonitor/BatteryMonitor.h"
 #include "../Logger/Logger.h"
-#include "../JbdBms/JbdBms.h"
+#include "../BluetoothBms/BluetoothBms.h"
 #include <cstdarg>
 #include <cstdio>
 
@@ -243,24 +243,25 @@ void Xctod::writeSystemStatus(char* data, size_t size, size_t& used) {
 }
 
 void Xctod::writeBmsInfo(char* data, size_t size, size_t& used) {
-    if (jbdBms.hasData() && jbdBms.getNtcCount() > 0) {
-        int16_t maxTemp = jbdBms.getNtcTempCelsius(0);
-        for (uint8_t i = 1; i < jbdBms.getNtcCount(); i++) {
-            int16_t t = jbdBms.getNtcTempCelsius(i);
+    // Use the BluetoothBms facade so this works with both JBD and Daly BMS types.
+    if (bluetoothBms.hasData() && bluetoothBms.getTempCount() > 0) {
+        int16_t maxTemp = bluetoothBms.getTempCelsius(0);
+        for (uint8_t i = 1; i < bluetoothBms.getTempCount(); i++) {
+            int16_t t = bluetoothBms.getTempCelsius(i);
             if (t > maxTemp) maxTemp = t;
         }
         appendToBuffer(data, size, used, ",%d", maxTemp);
     } else {
         appendToBuffer(data, size, used, ",");
     }
-    if (jbdBms.hasCellData()) {
+    if (bluetoothBms.hasCellData()) {
         appendToBuffer(
             data,
             size,
             used,
             ",%u,%u",
-            jbdBms.getCellMinMilliVolts(),
-            jbdBms.getCellMaxMilliVolts()
+            bluetoothBms.getCellMinMilliVolts(),
+            bluetoothBms.getCellMaxMilliVolts()
         );
     } else {
         appendToBuffer(data, size, used, ",,");

--- a/src/config.h
+++ b/src/config.h
@@ -150,6 +150,12 @@ extern ADS1115 ads1115;
 #define XAG_MOTOR_REACTION_DELAY_MS    1500
 #define XAG_WAKEUP_PWM_PERCENT        5
 
+// ========== WATCHDOG ==========
+// Task Watchdog timeout in seconds. The main loop must call esp_task_wdt_reset()
+// within this window or the system will reboot. 10 s is generous for a loop that
+// normally completes in <5 ms, but gives enough margin for BLE connect retries.
+#define WDT_TIMEOUT_S 10
+
 // ========== ESP32-C3 ADC CONFIGURATION ==========
 #define ADC_RESOLUTION 12        // 12-bit ADC (0-4095)
 #define ADC_MAX_VALUE 4095       // Maximum ADC reading

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <esp_system.h>
+#include <esp_task_wdt.h>
 
 #include <ESP32Servo.h>
 #if USES_CAN_BUS
@@ -111,6 +112,12 @@ void setup()
 
   esc.attach(ESC_PIN);
   esc.writeMicroseconds(ESC_MIN_PWM);
+
+  // Enable task watchdog on the main loop task. If loop() stalls for more than
+  // WDT_TIMEOUT_S seconds (e.g. a blocking BLE call or infinite loop), the
+  // system reboots automatically. esp_task_wdt_reset() is called each iteration.
+  esp_task_wdt_init(WDT_TIMEOUT_S, true);
+  esp_task_wdt_add(NULL);
 }
 
 void loop()
@@ -143,6 +150,8 @@ void loop()
   handleArmedBeep();
 
   webServer.handleClient();
+
+  esp_task_wdt_reset();
 }
 
 void handleButtonEvent(AceButton* aceButton, uint8_t eventType, uint8_t buttonState)


### PR DESCRIPTION
## Changes

### C1 — Task Watchdog Timer (`config.h`, `main.cpp`)
Added `WDT_TIMEOUT_S = 10` and enabled the ESP32 Task Watchdog on the main loop task. If `loop()` stalls for more than 10 seconds (blocking BLE call, infinite loop, etc.) the system reboots automatically. `esp_task_wdt_reset()` is called once per iteration.

Note: the reset reason (`ESP_RST_TASK_WDT = 6`) is already printed on boot via `esp_reset_reason()` at `main.cpp:39`, so a watchdog reboot is immediately visible on the serial monitor.

### C2 — BMS facade in Xctod (`Xctod.cpp`)
`writeBmsInfo()` was calling `jbdBms` directly. If the user configures a Daly BMS instead of JBD, `jbdBms.hasData()` is always false and BMS temperature/cell data is never sent to XCTRACK.

Replaced with the `bluetoothBms` facade methods which already abstract over both BMS types:
- `bluetoothBms.getTempCount()` / `getTempCelsius(i)` → was `jbdBms.getNtcCount()` / `getNtcTempCelsius(i)`
- `bluetoothBms.hasCellData()` / `getCellMinMilliVolts()` / `getCellMaxMilliVolts()` → same names on jbdBms

Also replaced the `#include "../JbdBms/JbdBms.h"` with `#include "../BluetoothBms/BluetoothBms.h"`.

### C3 — Battery capacity propagation (`ControllerWebServer.cpp`)
`batteryMonitor.setCapacity()` exists and is called at `init()` time, but when the user changes capacity in the web portal and saves, only `settings.setBatteryCapacityMah()` + `settings.save()` were called — the in-memory `BatteryMonitor` kept using the old value until reboot. Added the missing call immediately after `settings.save()`.

## Verification

- [x] Build `lolin_c3_mini_hobbywing` — SUCCESS
- [x] Build `lolin_c3_mini_tmotor` — SUCCESS
- [x] Build `lolin_c3_mini_xag` — SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)