### PR TITLE
feat: PIN-protected writes for config and OTA, path traversal fix

### DIFF
--- a/src/Settings/Settings.cpp
+++ b/src/Settings/Settings.cpp
@@ -47,6 +47,7 @@ bool isValidBmsMacFormat(const String& s) {
 } // namespace
 
 Settings::Settings() {
+    configPin = "0000";
     batteryCapacityMah = 0;
     batteryMinVoltage = 0;
     batteryMaxVoltage = 0;
@@ -105,6 +106,10 @@ void Settings::load() {
         }
     }
 
+    // Load config PIN (default "0000")
+    configPin = readBoundedPrefString(preferences, "cfgPin");
+    if (configPin.length() == 0) configPin = "0000";
+
     // Load throttle curve gamma (1.0 = linear; higher = less sensitive at low throttle)
     throttleCurveGamma = preferences.getFloat("thrCurveG", getDefaultThrottleCurveGamma());
 
@@ -149,6 +154,7 @@ void Settings::save() {
     // NVS writes are slow (~ms each); holding the mutex ensures the main loop
     // never reads a partially-updated snapshot of member variables while we write.
     if (mutex_) xSemaphoreTake(mutex_, portMAX_DELAY);
+    preferences.putString("cfgPin", configPin);
     preferences.putUInt("batCap", batteryCapacityMah);
     preferences.putUInt("batMinV", batteryMinVoltage);
     preferences.putUInt("batMaxV", batteryMaxVoltage);
@@ -315,4 +321,17 @@ uint8_t Settings::getDefaultBmsType() const {
 
 float Settings::getDefaultThrottleCurveGamma() const {
     return 1.0f;  // Linear response by default
+}
+
+String Settings::getConfigPin() const {
+    if (mutex_) xSemaphoreTake(mutex_, portMAX_DELAY);
+    String copy = configPin;
+    if (mutex_) xSemaphoreGive(mutex_);
+    return copy;
+}
+
+void Settings::setConfigPin(const String& pin) {
+    if (mutex_) xSemaphoreTake(mutex_, portMAX_DELAY);
+    configPin = pin;
+    if (mutex_) xSemaphoreGive(mutex_);
 }

--- a/src/Settings/Settings.h
+++ b/src/Settings/Settings.h
@@ -59,6 +59,10 @@ public:
     String getBmsMac() const;
     void setBmsMac(const char* mac);
 
+    // Config PIN — required on all write endpoints and OTA. Default: "0000".
+    String getConfigPin() const;
+    void setConfigPin(const String& pin);
+
 private:
     Preferences preferences;
     SemaphoreHandle_t mutex_;
@@ -77,6 +81,7 @@ private:
     float getDefaultThrottleCurveGamma() const;
 
     // Current values
+    String configPin;
     uint16_t batteryCapacityMah;
     uint16_t batteryMinVoltage;
     uint16_t batteryMaxVoltage;

--- a/src/WebServer/ControllerWebServer.cpp
+++ b/src/WebServer/ControllerWebServer.cpp
@@ -136,6 +136,13 @@ void sendSystemConfigResponse(AsyncWebServerRequest* request) {
     doc["wifiAutoDisableAfterCalibration"] = settings.getWifiAutoDisableAfterCalibration();
     sendJsonResponse(request, 200, doc);
 }
+
+// Returns true when the request carries the correct X-Config-Pin header.
+// All write endpoints (config save, delete, OTA) must call this first.
+bool checkPin(AsyncWebServerRequest* request) {
+    if (!request->hasHeader("X-Config-Pin")) return false;
+    return request->getHeader("X-Config-Pin")->value() == settings.getConfigPin();
+}
 } // namespace
 
 
@@ -194,6 +201,7 @@ void ControllerWebServer::startAP() {
 
     server.on("/api/bms/scan/start", HTTP_POST, [](AsyncWebServerRequest *request) {
         logWebHeap("/api/bms/scan/start");
+        if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
         const bool started = bluetoothBms.startWebScan();
         const int httpStatus = started ? 200 : 500;
         sendBmsScanStatusResponse(request, httpStatus);
@@ -228,6 +236,7 @@ void ControllerWebServer::startAP() {
         "/api/config/power",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/config/power POST");
+            if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
             if (!json.is<JsonObject>()) {
                 request->send(400, "text/plain", "Invalid JSON: body must be an object");
                 return;
@@ -290,6 +299,7 @@ void ControllerWebServer::startAP() {
         "/api/config/thermal",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/config/thermal POST");
+            if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
             if (!json.is<JsonObject>()) {
                 request->send(400, "text/plain", "Invalid JSON: body must be an object");
                 return;
@@ -348,6 +358,7 @@ void ControllerWebServer::startAP() {
         "/api/config/bms",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/config/bms POST");
+            if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
             if (!json.is<JsonObject>()) {
                 request->send(400, "text/plain", "Invalid JSON: body must be an object");
                 return;
@@ -411,6 +422,7 @@ void ControllerWebServer::startAP() {
         "/api/config/system",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/config/system POST");
+            if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
             if (!json.is<JsonObject>()) {
                 request->send(400, "text/plain", "Invalid JSON: body must be an object");
                 return;
@@ -431,6 +443,48 @@ void ControllerWebServer::startAP() {
     saveSystemHandler->setMethod(HTTP_POST);
     saveSystemHandler->setMaxContentLength(128);
     server.addHandler(saveSystemHandler);
+
+    // PIN management — GET: check if pin is "0000" (default); POST: change pin.
+    // The POST body must be { "currentPin": "xxxx", "newPin": "yyyy" }.
+    // newPin must be 4-8 characters. Current PIN is validated before applying.
+    server.on("/api/config/pin", HTTP_GET, [](AsyncWebServerRequest *request) {
+        DynamicJsonDocument doc(64);
+        doc["isDefault"] = (settings.getConfigPin() == "0000");
+        sendJsonResponse(request, 200, doc);
+    });
+
+    AsyncCallbackJsonWebHandler* savePinHandler = new AsyncCallbackJsonWebHandler(
+        "/api/config/pin",
+        [](AsyncWebServerRequest *request, JsonVariant &json) {
+            if (!json.is<JsonObject>()) {
+                request->send(400, "text/plain", "Invalid JSON");
+                return;
+            }
+            JsonObject doc = json.as<JsonObject>();
+            if (!doc.containsKey("currentPin") || !doc.containsKey("newPin")) {
+                request->send(400, "text/plain", "Missing currentPin or newPin");
+                return;
+            }
+            const String currentPin = doc["currentPin"].as<const char*>();
+            const String newPin     = doc["newPin"].as<const char*>();
+            if (currentPin != settings.getConfigPin()) {
+                request->send(403, "text/plain", "Current PIN is incorrect");
+                return;
+            }
+            if (newPin.length() < 4 || newPin.length() > 8) {
+                request->send(400, "text/plain", "New PIN must be 4-8 characters");
+                return;
+            }
+            settings.setConfigPin(newPin);
+            settings.save();
+            ElegantOTA.setAuth("admin", settings.getConfigPin().c_str());
+            request->send(200, "text/plain", "PIN updated successfully");
+        },
+        128
+    );
+    savePinHandler->setMethod(HTTP_POST);
+    savePinHandler->setMaxContentLength(128);
+    server.addHandler(savePinHandler);
 
     // Telemetry API
     server.on("/api/telemetry", HTTP_GET, [](AsyncWebServerRequest *request){
@@ -606,9 +660,14 @@ void ControllerWebServer::startAP() {
 
     // Delete file API
     server.on("/delete", HTTP_GET, [](AsyncWebServerRequest *request){
+        if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
         if(request->hasParam("file")){
             String filename = request->getParam("file")->value();
-            // Security: basic check to ensure we only delete what we expect
+            // Security: reject path traversal and ensure absolute path
+            if (filename.indexOf("..") >= 0) {
+                request->send(400, "text/plain", "Invalid path");
+                return;
+            }
             if(!filename.startsWith("/")) filename = "/" + filename;
 
             if(LittleFS.exists(filename)){
@@ -623,6 +682,7 @@ void ControllerWebServer::startAP() {
     });
 
     server.on("/delete-all-logs", HTTP_GET, [](AsyncWebServerRequest *request){
+        if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
         File root = LittleFS.open("/");
         if (!root) {
             request->send(500, "text/plain", "Filesystem error");
@@ -705,7 +765,8 @@ void ControllerWebServer::startAP() {
     });
 
     server.begin(); // Start the web server
-    ElegantOTA.begin(&server); // Start ElegantOTA
+    ElegantOTA.begin(&server);
+    ElegantOTA.setAuth("admin", settings.getConfigPin().c_str());
     Serial.println("Web server started.");
 }
 

--- a/src/WebServer/Pages/CommonScripts.h
+++ b/src/WebServer/Pages/CommonScripts.h
@@ -13,6 +13,14 @@ const setText = (id, value) => {
 
 const fetchJson = (url) => fetch(url).then((r) => r.json());
 
+const getPin = () => sessionStorage.getItem('cfgPin') || '';
+const setPin = (pin) => sessionStorage.setItem('cfgPin', pin);
+
+const fetchWithPin = (url, options = {}) => {
+    const headers = { ...(options.headers || {}), 'X-Config-Pin': getPin() };
+    return fetch(url, { ...options, headers });
+};
+
 const formatBytes = (bytes) => {
     if (bytes === 0) return '0 B';
     const k = 1024;

--- a/src/WebServer/Pages/ConfigBmsPage.h
+++ b/src/WebServer/Pages/ConfigBmsPage.h
@@ -54,6 +54,11 @@ static const char CONFIG_BMS_PAGE_HTML[] PROGMEM = R"rawliteral(
                     <div id="bmsScanResults" style="display: grid; gap: 10px; margin-top: 12px;"></div>
                 </div>
 
+                <div class="form-group">
+                    <label for="configPin">PIN</label>
+                    <input type="password" id="configPin" maxlength="8" placeholder="Required to save">
+                </div>
+
                 <button type="submit" id="saveButton">Save BMS Settings</button>
                 <div class="message" id="message"></div>
             </form>
@@ -67,6 +72,8 @@ static const char CONFIG_BMS_PAGE_HTML[] PROGMEM = R"rawliteral(
 
 static const char CONFIG_BMS_PAGE_JS[] PROGMEM = R"rawliteral(
 const $ = (id) => document.getElementById(id);
+const getPin = () => sessionStorage.getItem('cfgPin') || '';
+const setPin = (v) => sessionStorage.setItem('cfgPin', v);
 const BMS_TYPE_LABELS = {
     0: 'Unknown',
     1: 'JBD',
@@ -215,7 +222,7 @@ function loadBmsScanStatus() {
 const startBmsScan = () => {
     $('scanBmsButton').disabled = true;
     setBmsScanStatus('Starting BLE scan...');
-    fetch('/api/bms/scan/start', { method: 'POST' })
+    fetch('/api/bms/scan/start', { method: 'POST', headers: { 'X-Config-Pin': getPin() } })
         .then((response) => response.json())
         .then(applyBmsScanState)
         .catch((error) => {
@@ -264,9 +271,12 @@ $('bmsConfigForm').addEventListener('submit', function(e) {
         return;
     }
 
+    const pin = $('configPin').value;
+    setPin(pin);
+
     fetch('/api/config/bms', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Config-Pin': pin },
         body: JSON.stringify({
             bmsType: bmsType,
             bmsMac: bmsMac
@@ -282,6 +292,8 @@ $('bmsConfigForm').addEventListener('submit', function(e) {
             saveButton.disabled = false;
         });
 });
+
+window.addEventListener('DOMContentLoaded', () => { $('configPin').value = getPin(); });
 
 loadCurrentValues();
 loadBmsScanStatus();

--- a/src/WebServer/Pages/ConfigPowerPage.h
+++ b/src/WebServer/Pages/ConfigPowerPage.h
@@ -78,6 +78,11 @@ static const char CONFIG_POWER_PAGE_HTML[] PROGMEM = R"rawliteral(
                     <div class="info-text">Power-law curve: 1.0 = linear; higher values = less sensitive at low throttle, more responsive at high throttle.</div>
                 </div>
 
+                <div class="form-group">
+                    <label for="configPin">PIN</label>
+                    <input type="password" id="configPin" maxlength="8" placeholder="Required to save">
+                </div>
+
                 <button type="submit" id="saveButton">Save Power Settings</button>
                 <div class="message" id="message"></div>
             </form>
@@ -92,6 +97,8 @@ static const char CONFIG_POWER_PAGE_HTML[] PROGMEM = R"rawliteral(
 static const char CONFIG_POWER_PAGE_JS[] PROGMEM = R"rawliteral(
 const $ = (id) => document.getElementById(id);
 const CELL_COUNT = 14;
+const getPin = () => sessionStorage.getItem('cfgPin') || '';
+const setPin = (v) => sessionStorage.setItem('cfgPin', v);
 
 const showMessage = (text, kind) => {
     const el = $('message');
@@ -181,9 +188,12 @@ $('powerConfigForm').addEventListener('submit', function(e) {
         throttleCurveGamma: throttleCurveGamma
     };
 
+    const pin = $('configPin').value;
+    setPin(pin);
+
     fetch('/api/config/power', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Config-Pin': pin },
         body: JSON.stringify(data)
     })
         .then((response) => response.text().then((text) => ({ ok: response.ok, text })))
@@ -196,6 +206,9 @@ $('powerConfigForm').addEventListener('submit', function(e) {
             saveButton.disabled = false;
         });
 });
+
+// Pre-fill PIN from sessionStorage
+window.addEventListener('DOMContentLoaded', () => { $('configPin').value = getPin(); });
 
 loadCurrentValues();
 )rawliteral";

--- a/src/WebServer/Pages/ConfigSystemPage.h
+++ b/src/WebServer/Pages/ConfigSystemPage.h
@@ -40,6 +40,11 @@ static const char CONFIG_SYSTEM_PAGE_HTML[] PROGMEM = R"rawliteral(
                     <div class="info-text">When enabled, access point and web server are stopped automatically after throttle calibration completes.</div>
                 </div>
 
+                <div class="form-group">
+                    <label for="configPin">PIN</label>
+                    <input type="password" id="configPin" maxlength="8" placeholder="Required to save">
+                </div>
+
                 <button type="submit" id="saveButton">Save System Settings</button>
                 <div class="message" id="message"></div>
             </form>
@@ -53,6 +58,8 @@ static const char CONFIG_SYSTEM_PAGE_HTML[] PROGMEM = R"rawliteral(
 
 static const char CONFIG_SYSTEM_PAGE_JS[] PROGMEM = R"rawliteral(
 const $ = (id) => document.getElementById(id);
+const getPin = () => sessionStorage.getItem('cfgPin') || '';
+const setPin = (v) => sessionStorage.setItem('cfgPin', v);
 
 const showMessage = (text, kind) => {
     const el = $('message');
@@ -81,9 +88,12 @@ $('systemConfigForm').addEventListener('submit', function(e) {
     saveButton.disabled = true;
     $('message').style.display = 'none';
 
+    const pin = $('configPin').value;
+    setPin(pin);
+
     fetch('/api/config/system', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Config-Pin': pin },
         body: JSON.stringify({
             wifiAutoDisableAfterCalibration: $('wifiAutoDisableAfterCalibration').checked
         })
@@ -98,6 +108,8 @@ $('systemConfigForm').addEventListener('submit', function(e) {
             saveButton.disabled = false;
         });
 });
+
+window.addEventListener('DOMContentLoaded', () => { $('configPin').value = getPin(); });
 
 loadCurrentValues();
 )rawliteral";

--- a/src/WebServer/Pages/ConfigThermalPage.h
+++ b/src/WebServer/Pages/ConfigThermalPage.h
@@ -60,6 +60,11 @@ static const char CONFIG_THERMAL_PAGE_HTML[] PROGMEM = R"rawliteral(
                     <div class="info-text">Power reduction begins at this temperature and increases linearly until maximum temperature.</div>
                 </div>
 
+                <div class="form-group">
+                    <label for="configPin">PIN</label>
+                    <input type="password" id="configPin" maxlength="8" placeholder="Required to save">
+                </div>
+
                 <button type="submit" id="saveButton">Save Thermal Settings</button>
                 <div class="message" id="message"></div>
             </form>
@@ -73,6 +78,8 @@ static const char CONFIG_THERMAL_PAGE_HTML[] PROGMEM = R"rawliteral(
 
 static const char CONFIG_THERMAL_PAGE_JS[] PROGMEM = R"rawliteral(
 const $ = (id) => document.getElementById(id);
+const getPin = () => sessionStorage.getItem('cfgPin') || '';
+const setPin = (v) => sessionStorage.setItem('cfgPin', v);
 
 const showMessage = (text, kind) => {
     const el = $('message');
@@ -111,9 +118,12 @@ $('thermalConfigForm').addEventListener('submit', function(e) {
         escTempReductionStart: Math.round(parseFloat($('escTempReductionStart').value) * 1000)
     };
 
+    const pin = $('configPin').value;
+    setPin(pin);
+
     fetch('/api/config/thermal', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Config-Pin': pin },
         body: JSON.stringify(data)
     })
         .then((response) => response.text().then((text) => ({ ok: response.ok, text })))
@@ -126,6 +136,8 @@ $('thermalConfigForm').addEventListener('submit', function(e) {
             saveButton.disabled = false;
         });
 });
+
+window.addEventListener('DOMContentLoaded', () => { $('configPin').value = getPin(); });
 
 loadCurrentValues();
 )rawliteral";

--- a/src/WebServer/Pages/LogsPage.h
+++ b/src/WebServer/Pages/LogsPage.h
@@ -6,6 +6,10 @@ inline String renderLogsPage() {
     const char* body = R"rawliteral(
 <div class="panel">
     <h1>Data Logs</h1>
+    <div class="form-group" style="max-width:320px;margin-bottom:1rem;">
+        <label for="logPin">PIN</label>
+        <input type="password" id="logPin" maxlength="8" placeholder="Required to delete" oninput="setPin(this.value)">
+    </div>
     <div class="table-wrap">
         <table id="fileTable">
             <thead><tr><th>File</th><th>Size</th><th>Action</th></tr></thead>
@@ -57,15 +61,23 @@ const loadFiles = () => {
 
 const deleteFile = (filename) => {
     if (!confirm(`Delete ${filename}?`)) return;
-    fetch('/delete?file=' + filename).then((r) => r.ok ? loadFiles() : alert('Delete failed'));
+    fetchWithPin('/delete?file=' + encodeURIComponent(filename))
+        .then((r) => r.ok ? loadFiles() : r.text().then((t) => alert('Delete failed: ' + t)));
 };
 
 const deleteAllLogs = () => {
     const deleteAllBtn = document.querySelector('#deleteAllBtn');
     if (deleteAllBtn && deleteAllBtn.disabled) return;
     if (!confirm('This will permanently delete all log files on the device. Continue?')) return;
-    fetch('/delete-all-logs').then((r) => (r.ok ? loadFiles() : alert('Delete all failed')));
+    fetchWithPin('/delete-all-logs')
+        .then((r) => r.ok ? loadFiles() : r.text().then((t) => alert('Delete failed: ' + t)));
 };
+
+// Pre-fill PIN from sessionStorage on page load
+window.addEventListener('DOMContentLoaded', () => {
+    const pinInput = document.querySelector('#logPin');
+    if (pinInput) pinInput.value = getPin();
+});
 
 loadFiles();
 )rawliteral";


### PR DESCRIPTION
## Summary

WiFi AP stays open (easy field access), but all write operations now require a PIN sent as the `X-Config-Pin` HTTP header. OTA is protected via ElegantOTA HTTP Basic Auth. Default PIN is `0000` — user should change it on first use via `/api/config/pin`.

## Changes

### Settings (`Settings.h/.cpp`)
- `getConfigPin()` / `setConfigPin()` — persisted to NVS under key `cfgPin`, default `"0000"`
- Access protected by the existing `mutex_` (String is a heap-allocated object)

### Backend (`ControllerWebServer.cpp`)
- `checkPin(request)` helper: reads `X-Config-Pin` header, compares with stored PIN
- Returns **403** if header is absent or wrong
- Protected endpoints: `POST /api/bms/scan/start`, `POST /api/config/power`, `POST /api/config/thermal`, `POST /api/config/bms`, `POST /api/config/system`, `GET /delete`, `GET /delete-all-logs`
- `GET /api/config/pin` — returns `{"isDefault": true/false}` (no PIN revealed)
- `POST /api/config/pin` — body `{"currentPin","newPin"}`, validates current PIN, enforces 4-8 char length, updates ElegantOTA auth immediately
- `ElegantOTA.setAuth("admin", pin)` called at startup and after any PIN change
- `/delete`: reject paths containing `..` before any filesystem access (path traversal fix)

### Frontend
- `CommonScripts.h`: `getPin()` / `setPin()` (sessionStorage `cfgPin`), `fetchWithPin()` wrapper
- **Logs page**: delete functions use `fetchWithPin`; PIN input pre-filled from sessionStorage
- **All config pages** (Power, Thermal, BMS, System): PIN input field added before Save button; PIN stored to sessionStorage on submit; `X-Config-Pin` header injected on every POST

## Verification

- [x] Build `lolin_c3_mini_hobbywing` — SUCCESS
- [x] Build `lolin_c3_mini_tmotor` — SUCCESS
- [x] Build `lolin_c3_mini_xag` — SUCCESS

## Test plan
- [ ] POST config without PIN → 403
- [ ] POST config with wrong PIN → 403
- [ ] POST config with correct PIN → 200, settings persisted
- [ ] Change PIN via `/api/config/pin` → OTA page now requires new PIN
- [ ] Delete log without PIN → 403
- [ ] Delete log with `../etc/passwd` as filename → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)