### PR TITLE
chore: pin library versions, enable -Wall -Wextra, fix all warnings

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,22 +14,27 @@ default_envs = lolin_c3_mini
 
 ; Common configuration for all environments
 [env]
-platform = espressif32
+platform = espressif32@6.12.0
 board = lolin_c3_mini
 framework = arduino
 monitor_speed = 115200
 lib_compat_mode = strict
-build_flags = -D ELEGANTOTA_USE_ASYNC_WEBSERVER=1
+build_flags =
+	-D ELEGANTOTA_USE_ASYNC_WEBSERVER=1
+build_src_flags =
+	-Wall
+	-Wextra
+	-Wno-unused-parameter
 board_build.filesystem = littlefs
 board_build.partitions = min_spiffs.csv
 lib_deps =
-	bxparks/AceButton@^1.10.1
-	madhephaestus/ESP32Servo
-	https://github.com/me-no-dev/ESPAsyncWebServer.git
-	ayushsharma82/ElegantOTA
-	AsyncTCP
-	adafruit/Adafruit ADS1X15@^2.4.6
-	bblanchon/ArduinoJson@^6.21.3
+	bxparks/AceButton@1.10.1
+	madhephaestus/ESP32Servo@3.1.2
+	https://github.com/me-no-dev/ESPAsyncWebServer.git#ad3741d159f9cfd50c567e81b67f3bef1dc6d89f
+	ayushsharma82/ElegantOTA@3.1.7
+	AsyncTCP@3.4.10
+	adafruit/Adafruit ADS1X15@2.6.2
+	bblanchon/ArduinoJson@6.21.5
 
 ; Default environment: Hobbywing controller (uses CAN bus)
 [env:lolin_c3_mini]

--- a/src/ADS1115/ADS1115.cpp
+++ b/src/ADS1115/ADS1115.cpp
@@ -32,11 +32,11 @@ bool ADS1115::begin(uint8_t sdaPin, uint8_t sclPin) {
 }
 
 int ADS1115::readChannel(uint8_t channel) {
-    if (!initialized) {
-        return lastValue[channel];
+    if (channel > 3) {
+        return 0;  // Invalid channel — array has only 4 elements [0..3]
     }
 
-    if (channel > 3) {
+    if (!initialized) {
         return lastValue[channel];
     }
 

--- a/src/DalyBms/DalyBms.cpp
+++ b/src/DalyBms/DalyBms.cpp
@@ -440,7 +440,7 @@ uint16_t DalyBms::crc16Modbus(const uint8_t* data, size_t len) {
 void DalyBms::printFrameHex(const uint8_t* data, size_t len) const {
     DEBUG_PRINT("[Daly] ");
     for (size_t i = 0; i < len; i++) {
-        if (data[i] < 0x10) DEBUG_PRINT("0");
+        if (data[i] < 0x10) { DEBUG_PRINT("0"); }
         DEBUG_PRINT_HEX(data[i], HEX);
         DEBUG_PRINT(" ");
     }
@@ -453,8 +453,8 @@ void DalyBms::printStatusSummary() const {
     DEBUG_PRINT(packVoltageMilliVolts_ / 1000);
     DEBUG_PRINT(".");
     uint16_t voltageFraction = packVoltageMilliVolts_ % 1000;
-    if (voltageFraction < 100) DEBUG_PRINT("0");
-    if (voltageFraction < 10) DEBUG_PRINT("0");
+    if (voltageFraction < 100) { DEBUG_PRINT("0"); }
+    if (voltageFraction < 10)  { DEBUG_PRINT("0"); }
     DEBUG_PRINT(voltageFraction);
     DEBUG_PRINTLN(" V");
     DEBUG_PRINT("[Daly] Current: ");
@@ -500,14 +500,14 @@ void DalyBms::printCellVoltages() const {
     for (uint8_t i = 0; i < cellCount_ && i < MAX_CELLS; i++) {
         uint16_t v = cellVoltagesMv_[i];
         DEBUG_PRINT("[Daly] C");
-        if (i + 1 < 10) DEBUG_PRINT("0");
+        if (i + 1 < 10) { DEBUG_PRINT("0"); }
         DEBUG_PRINT(i + 1);
         DEBUG_PRINT(": ");
         DEBUG_PRINT(v / 1000);
         DEBUG_PRINT(".");
         uint16_t frac = v % 1000;
-        if (frac < 100) DEBUG_PRINT("0");
-        if (frac < 10) DEBUG_PRINT("0");
+        if (frac < 100) { DEBUG_PRINT("0"); }
+        if (frac < 10)  { DEBUG_PRINT("0"); }
         DEBUG_PRINT(frac);
         DEBUG_PRINTLN(" V");
     }

--- a/src/Hobbywing/HobbywingCan.cpp
+++ b/src/Hobbywing/HobbywingCan.cpp
@@ -187,6 +187,8 @@ void HobbywingCan::handleGetEscIdResponse(twai_message_t *canMsg) {
 
     uint8_t escThrottleIdReceived = getEscThrottleIdFromPayload(canMsg->data);
     uint8_t sourceNodeId = CanUtils::getNodeIdFromCanId(canMsg->identifier);
+    (void)escThrottleIdReceived; // only used in DEBUG_PRINT
+    (void)sourceNodeId;          // only used in DEBUG_PRINT
 
     DEBUG_PRINT("Received GetEscID response from Node ID: ");
     DEBUG_PRINT_HEX(sourceNodeId, HEX);

--- a/src/JbdBms/JbdBms.cpp
+++ b/src/JbdBms/JbdBms.cpp
@@ -584,15 +584,15 @@ void JbdBms::printCellVoltages() {
     for (uint8_t i = 0; i < count && i < JBD_MAX_CELLS; i++) {
         uint16_t v = cellVoltagesMv_[i];
         DEBUG_PRINT("[JBD] C");
-        if (i + 1 < 10) DEBUG_PRINT("0");
+        if (i + 1 < 10) { DEBUG_PRINT("0"); }
         DEBUG_PRINT(i + 1);
         DEBUG_PRINT(": ");
         DEBUG_PRINT(v / 1000);
         DEBUG_PRINT(".");
         // 3 decimal places
         uint16_t frac = v % 1000;
-        if (frac < 100) DEBUG_PRINT("0");
-        if (frac < 10)  DEBUG_PRINT("0");
+        if (frac < 100) { DEBUG_PRINT("0"); }
+        if (frac < 10)  { DEBUG_PRINT("0"); }
         DEBUG_PRINT(frac);
         DEBUG_PRINTLN(" V");
         if (v < vmin) vmin = v;
@@ -644,7 +644,7 @@ uint16_t JbdBms::getCellDeltaMilliVolts() const {
 void JbdBms::printFrameHex(const uint8_t* data, size_t len) {
     DEBUG_PRINT("[JBD] ");
     for (size_t i = 0; i < len; i++) {
-        if (data[i] < 0x10) DEBUG_PRINT("0");
+        if (data[i] < 0x10) { DEBUG_PRINT("0"); }
         DEBUG_PRINT_HEX(data[i], HEX);
         DEBUG_PRINT(" ");
     }

--- a/src/Power/Power.cpp
+++ b/src/Power/Power.cpp
@@ -78,11 +78,12 @@ unsigned int Power::getPwm() {
             if (now - startingBeganAt >= XAG_MOTOR_REACTION_DELAY_MS) {
                 startState = StartState::RUNNING;
                 outputPwm = wakeupPwm;
-                // Fall through to RUNNING
+                // intentional: transition to RUNNING on same tick — [[fallthrough]] below
             } else {
                 outputPwm = wakeupPwm;
                 return (unsigned int)outputPwm;
             }
+            [[fallthrough]]; // intentional: after delay expires, execute RUNNING logic immediately
         }
         case StartState::RUNNING:
             if (!throttleActive) {

--- a/src/Temperature/Temperature.cpp
+++ b/src/Temperature/Temperature.cpp
@@ -30,7 +30,7 @@ void Temperature::handle()
 }
 
 void Temperature::readTemperature() {
-  memcpy(
+  memmove(
     &pinValues,
     &pinValues[1],
     sizeof(pinValues[0]) * (samples - 1)

--- a/src/Throttle/Throttle.cpp
+++ b/src/Throttle/Throttle.cpp
@@ -139,7 +139,7 @@ void Throttle::handleCalibration(unsigned long now)
 
 void Throttle::readThrottlePin()
 {
-  memcpy(
+  memmove(
     &pinValues,
     &pinValues[1],
     sizeof(pinValues[0]) * (samples - 1)

--- a/src/Tmotor/TmotorCan.cpp
+++ b/src/Tmotor/TmotorCan.cpp
@@ -70,8 +70,6 @@ TmotorCan::TmotorCan() {
 void TmotorCan::parseEscMessage(twai_message_t *canMsg) {
     // Extract DataType ID from CAN ID (assuming DroneCAN format)
     uint16_t dataTypeId = CanUtils::getDataTypeIdFromCanId(canMsg->identifier);
-    uint8_t sourceNodeId = CanUtils::getNodeIdFromCanId(canMsg->identifier);
-
     // Route to appropriate handler
     if (dataTypeId == escStatusDataTypeId) {
         handleEscStatus(canMsg);
@@ -89,8 +87,8 @@ void TmotorCan::parseEscMessage(twai_message_t *canMsg) {
         DEBUG_PRINT(canMsg->data_length_code);
         DEBUG_PRINT(" Data=[");
         for (uint8_t i = 0; i < canMsg->data_length_code && i < 8; i++) {
-            if (i > 0) DEBUG_PRINT(" ");
-            if (canMsg->data[i] < 0x10) DEBUG_PRINT("0");
+            if (i > 0) { DEBUG_PRINT(" "); }
+            if (canMsg->data[i] < 0x10) { DEBUG_PRINT("0"); }
             DEBUG_PRINT_HEX(canMsg->data[i], HEX);
         }
         DEBUG_PRINTLN("]");
@@ -364,6 +362,7 @@ void TmotorCan::handleEscStatus5(twai_message_t *canMsg) {
 
     int16_t idc = (int16_t)((uint16_t)canMsg->data[0] |
                             ((uint16_t)canMsg->data[1] << 8));
+    (void)idc; // only used in DEBUG_PRINT — suppress unused-variable in release builds
 
     int16_t cap_temp_raw = (int16_t)((uint16_t)canMsg->data[2] |
                                      ((uint16_t)canMsg->data[3] << 8));
@@ -375,6 +374,7 @@ void TmotorCan::handleEscStatus5(twai_message_t *canMsg) {
     // For positive values: (value + 5) / 10 rounds correctly
     // For negative values: (value - 5) / 10 rounds correctly
     int16_t cap_temp_celsius = (cap_temp_raw >= 0) ? (cap_temp_raw + 5) / 10 : (cap_temp_raw - 5) / 10;
+    (void)cap_temp_celsius; // only used in DEBUG_PRINT — suppress unused-variable in release builds
     int16_t motor_temp_celsius = (motor_temp_raw >= 0) ? (motor_temp_raw + 5) / 10 : (motor_temp_raw - 5) / 10;
 
     // Store (convert to uint8_t, with range check)
@@ -403,12 +403,7 @@ void TmotorCan::handleEscStatus5(twai_message_t *canMsg) {
 
 
 void TmotorCan::requestParam(uint16_t paramIndex) {
-    // Send ParamGet service request to read ESC parameter
-    // Service ID for ParamGet is typically 10 (uavcan.protocol.param.GetSet)
-    twai_message_t localCanMsg;
-
-    // For now, this is a placeholder - ParamGet structure needs to be defined
-    // based on the actual DroneCAN specification
+    // Placeholder — ParamGet structure needs to be defined per DroneCAN spec
     DEBUG_PRINT("[Tmotor] ParamGet request not yet implemented for param index ");
     DEBUG_PRINTLN(paramIndex);
 }

--- a/src/WebServer/ControllerWebServer.cpp
+++ b/src/WebServer/ControllerWebServer.cpp
@@ -253,11 +253,14 @@ void ControllerWebServer::startAP() {
                 return;
             }
 
-            uint16_t capacity = doc["batteryCapacity"];
-            if (capacity < 1000 || capacity > 200000) {
-                request->send(400, "text/plain", "Battery capacity out of range (1000-200000 mAh)");
+            // Read as uint32_t first so the upper-bound check is meaningful —
+            // uint16_t max is 65535, so "> 65000" would otherwise always be false.
+            uint32_t capacityRaw = doc["batteryCapacity"].as<uint32_t>();
+            if (capacityRaw < 1000 || capacityRaw > 65000) {
+                request->send(400, "text/plain", "Battery capacity out of range (1000-65000 mAh)");
                 return;
             }
+            uint16_t capacity = static_cast<uint16_t>(capacityRaw);
 
             uint16_t minV = doc["batteryMinVoltage"];
             if (minV < 2500 || minV > 63000) {


### PR DESCRIPTION
## Summary

Two independent improvements bundled together since E2 depends on seeing what E1 breaks.

### E1 — Pin library versions (`platformio.ini`)

All dependencies now have exact versions instead of `^` ranges or bare git URLs:

| Library | Before | After |
|---|---|---|
| `espressif32` | `espressif32` (unpinned) | `espressif32@6.12.0` |
| `AceButton` | `^1.10.1` | `1.10.1` |
| `ESP32Servo` | unpinned | `3.1.2` |
| `ESPAsyncWebServer` | `git HEAD` | `git#ad3741d` |
| `ElegantOTA` | unpinned | `3.1.7` |
| `AsyncTCP` | unpinned | `3.4.10` |
| `Adafruit ADS1X15` | `^2.4.6` | `2.6.2` |
| `ArduinoJson` | `^6.21.3` | `6.21.5` |

### E2 — Compiler warnings (`build_src_flags`)

`-Wall -Wextra -Wno-unused-parameter` applied to **our source only** via `build_src_flags` (not `build_flags`) so library code in `.pio/libdeps/` is unaffected.

**All warnings fixed — zero remaining across all 3 targets:**

| File | Warning | Fix |
|---|---|---|
| `ADS1115.cpp` | Array out of bounds: `lastValue[channel]` with `channel > 3` | Guard bounds check first, return 0 on invalid channel |
| `Throttle.cpp`, `Temperature.cpp` | `-Wrestrict`: `memcpy` on overlapping ring buffer | `memcpy` → `memmove` (overlapping regions are UB with memcpy) |
| `Power.cpp` | `[[fallthrough]]` inside `if` block not recognized | Moved to end of `case` scope after the `if-else` |
| `ControllerWebServer.cpp` | `uint16_t > 200000` always false | Read as `uint32_t`, validate against 65000, then cast |
| `TmotorCan.cpp` | Unused vars (`idc`, `cap_temp_celsius`, `localCanMsg`); empty-body ifs | `(void)` casts; remove unused `localCanMsg`; add braces |
| `HobbywingCan.cpp` | Unused vars only used in `DEBUG_PRINT` | `(void)` casts |
| `JbdBms.cpp`, `DalyBms.cpp` | Empty-body ifs (`DEBUG_PRINT` compiles to nothing) | Add braces to all single-statement `if`/`if-else` bodies |

The `ADS1115` and `memcpy`→`memmove` fixes are real correctness issues, not just style. The rest are cleanliness fixes.

## Verification

- [x] Build `lolin_c3_mini_hobbywing` — SUCCESS, 0 warnings
- [x] Build `lolin_c3_mini_tmotor` — SUCCESS, 0 warnings
- [x] Build `lolin_c3_mini_xag` — SUCCESS, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)