### PR TITLE
i18n: translate web UI to Brazilian Portuguese (pt-BR)

### DIFF
--- a/src/WebServer/ControllerWebServer.cpp
+++ b/src/WebServer/ControllerWebServer.cpp
@@ -57,7 +57,7 @@ template <typename TJson>
 void sendJsonResponse(AsyncWebServerRequest* request, int httpStatus, const TJson& json) {
     AsyncResponseStream* response = request->beginResponseStream("application/json");
     if (response == nullptr) {
-        request->send(500, "text/plain", "Out of memory");
+        request->send(500, "text/plain", "Sem memória");
         return;
     }
     response->setCode(httpStatus);
@@ -103,7 +103,7 @@ void sendBmsScanStatusResponse(AsyncWebServerRequest* request, int httpStatus = 
     }
 
     if (doc.overflowed()) {
-        request->send(500, "text/plain", "JSON buffer overflow");
+        request->send(500, "text/plain", "Estouro do buffer JSON");
         return;
     }
 
@@ -118,7 +118,7 @@ void sendPowerConfigResponse(AsyncWebServerRequest* request) {
     doc["powerControlEnabled"] = settings.getPowerControlEnabled();
     doc["throttleCurveGamma"] = settings.getThrottleCurveGamma();
     if (doc.overflowed()) {
-        request->send(500, "text/plain", "JSON buffer overflow");
+        request->send(500, "text/plain", "Estouro do buffer JSON");
         return;
     }
     sendJsonResponse(request, 200, doc);
@@ -131,7 +131,7 @@ void sendThermalConfigResponse(AsyncWebServerRequest* request) {
     doc["escMaxTemp"] = settings.getEscMaxTemp();
     doc["escTempReductionStart"] = settings.getEscTempReductionStart();
     if (doc.overflowed()) {
-        request->send(500, "text/plain", "JSON buffer overflow");
+        request->send(500, "text/plain", "Estouro do buffer JSON");
         return;
     }
     sendJsonResponse(request, 200, doc);
@@ -142,7 +142,7 @@ void sendBmsConfigResponse(AsyncWebServerRequest* request) {
     doc["bmsType"] = settings.getBmsType();
     doc["bmsMac"] = settings.getBmsMac();
     if (doc.overflowed()) {
-        request->send(500, "text/plain", "JSON buffer overflow");
+        request->send(500, "text/plain", "Estouro do buffer JSON");
         return;
     }
     sendJsonResponse(request, 200, doc);
@@ -152,7 +152,7 @@ void sendSystemConfigResponse(AsyncWebServerRequest* request) {
     StaticJsonDocument<128> doc;
     doc["wifiAutoDisableAfterCalibration"] = settings.getWifiAutoDisableAfterCalibration();
     if (doc.overflowed()) {
-        request->send(500, "text/plain", "JSON buffer overflow");
+        request->send(500, "text/plain", "Estouro do buffer JSON");
         return;
     }
     sendJsonResponse(request, 200, doc);
@@ -222,7 +222,7 @@ void ControllerWebServer::startAP() {
 
     server.on("/api/bms/scan/start", HTTP_POST, [](AsyncWebServerRequest *request) {
         logWebHeap("/api/bms/scan/start");
-        if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
+        if (!checkPin(request)) { request->send(403, "text/plain", "PIN inválido"); return; }
         const bool started = bluetoothBms.startWebScan();
         const int httpStatus = started ? 200 : 500;
         sendBmsScanStatusResponse(request, httpStatus);
@@ -233,7 +233,7 @@ void ControllerWebServer::startAP() {
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/bms/detect");
             if (!json.is<JsonObject>()) {
-                request->send(400, "application/json", "{\"ok\":false,\"error\":\"Invalid JSON\"}");
+                request->send(400, "application/json", "{\"ok\":false,\"error\":\"JSON inválido\"}");
                 return;
             }
 
@@ -246,7 +246,7 @@ void ControllerWebServer::startAP() {
             responseDoc["mac"] = mac;
             responseDoc["detectedType"] = detectedType;
             if (responseDoc.overflowed()) {
-                request->send(500, "text/plain", "JSON buffer overflow");
+                request->send(500, "text/plain", "Estouro do buffer JSON");
                 return;
             }
             sendJsonResponse(request, 200, responseDoc);
@@ -261,9 +261,9 @@ void ControllerWebServer::startAP() {
         "/api/config/power",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/config/power POST");
-            if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
+            if (!checkPin(request)) { request->send(403, "text/plain", "PIN inválido"); return; }
             if (!json.is<JsonObject>()) {
-                request->send(400, "text/plain", "Invalid JSON: body must be an object");
+                request->send(400, "text/plain", "JSON inválido: o corpo deve ser um objeto");
                 return;
             }
 
@@ -274,7 +274,7 @@ void ControllerWebServer::startAP() {
                 || !doc.containsKey("batteryMaxVoltage")
                 || !doc.containsKey("powerControlEnabled")
                 || !doc.containsKey("throttleCurveGamma")) {
-                request->send(400, "text/plain", "Missing required power configuration fields");
+                request->send(400, "text/plain", "Campos obrigatórios de configuração de energia ausentes");
                 return;
             }
 
@@ -282,26 +282,26 @@ void ControllerWebServer::startAP() {
             // uint16_t max is 65535, so "> 65000" would otherwise always be false.
             uint32_t capacityRaw = doc["batteryCapacity"].as<uint32_t>();
             if (capacityRaw < 1000 || capacityRaw > 65000) {
-                request->send(400, "text/plain", "Battery capacity out of range (1000-65000 mAh)");
+                request->send(400, "text/plain", "Capacidade da bateria fora do intervalo (1000-65000 mAh)");
                 return;
             }
             uint16_t capacity = static_cast<uint16_t>(capacityRaw);
 
             uint16_t minV = doc["batteryMinVoltage"];
             if (minV < 2500 || minV > 63000) {
-                request->send(400, "text/plain", "Battery min voltage out of range");
+                request->send(400, "text/plain", "Tensão mínima da bateria fora do intervalo");
                 return;
             }
 
             uint16_t maxV = doc["batteryMaxVoltage"];
             if (maxV < 2500 || maxV > 63000) {
-                request->send(400, "text/plain", "Battery max voltage out of range");
+                request->send(400, "text/plain", "Tensão máxima da bateria fora do intervalo");
                 return;
             }
 
             float gamma = doc["throttleCurveGamma"].as<float>();
             if (gamma < 1.0f || gamma > 3.0f) {
-                request->send(400, "text/plain", "Throttle curve gamma must be between 1.0 and 3.0");
+                request->send(400, "text/plain", "O gamma da curva do acelerador deve ser entre 1,0 e 3,0");
                 return;
             }
 
@@ -315,7 +315,7 @@ void ControllerWebServer::startAP() {
             // setting — without this, Coulomb counting uses the old value until reboot.
             batteryMonitor.setCapacity(settings.getBatteryCapacityMah());
 
-            request->send(200, "text/plain", "Success: Power configuration saved");
+            request->send(200, "text/plain", "Sucesso: Configurações de energia salvas");
         },
         512
     );
@@ -327,9 +327,9 @@ void ControllerWebServer::startAP() {
         "/api/config/thermal",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/config/thermal POST");
-            if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
+            if (!checkPin(request)) { request->send(403, "text/plain", "PIN inválido"); return; }
             if (!json.is<JsonObject>()) {
-                request->send(400, "text/plain", "Invalid JSON: body must be an object");
+                request->send(400, "text/plain", "JSON inválido: o corpo deve ser um objeto");
                 return;
             }
 
@@ -339,7 +339,7 @@ void ControllerWebServer::startAP() {
                 || !doc.containsKey("motorTempReductionStart")
                 || !doc.containsKey("escMaxTemp")
                 || !doc.containsKey("escTempReductionStart")) {
-                request->send(400, "text/plain", "Missing required thermal configuration fields");
+                request->send(400, "text/plain", "Campos obrigatórios de configuração térmica ausentes");
                 return;
             }
 
@@ -349,22 +349,22 @@ void ControllerWebServer::startAP() {
             int32_t escReductionStart = doc["escTempReductionStart"];
 
             if (motorMaxTemp < 0 || motorMaxTemp > 150000) {
-                request->send(400, "text/plain", "Motor max temp out of range (0-150000 millicelsius)");
+                request->send(400, "text/plain", "Temperatura máxima do motor fora do intervalo (0-150000 millicelsius)");
                 return;
             }
 
             if (motorReductionStart < 0 || motorReductionStart > 150000) {
-                request->send(400, "text/plain", "Motor temp reduction start out of range");
+                request->send(400, "text/plain", "Início de redução de temperatura do motor fora do intervalo");
                 return;
             }
 
             if (escMaxTemp < 0 || escMaxTemp > 150000) {
-                request->send(400, "text/plain", "ESC max temp out of range");
+                request->send(400, "text/plain", "Temperatura máxima do ESC fora do intervalo");
                 return;
             }
 
             if (escReductionStart < 0 || escReductionStart > 150000) {
-                request->send(400, "text/plain", "ESC temp reduction start out of range");
+                request->send(400, "text/plain", "Início de redução de temperatura do ESC fora do intervalo");
                 return;
             }
 
@@ -374,7 +374,7 @@ void ControllerWebServer::startAP() {
             settings.setEscTempReductionStart(escReductionStart);
             settings.save();
 
-            request->send(200, "text/plain", "Success: Thermal configuration saved");
+            request->send(200, "text/plain", "Sucesso: Configurações térmicas salvas");
         },
         512
     );
@@ -386,21 +386,21 @@ void ControllerWebServer::startAP() {
         "/api/config/bms",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/config/bms POST");
-            if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
+            if (!checkPin(request)) { request->send(403, "text/plain", "PIN inválido"); return; }
             if (!json.is<JsonObject>()) {
-                request->send(400, "text/plain", "Invalid JSON: body must be an object");
+                request->send(400, "text/plain", "JSON inválido: o corpo deve ser um objeto");
                 return;
             }
 
             JsonObject doc = json.as<JsonObject>();
             if (!doc.containsKey("bmsType") || !doc.containsKey("bmsMac")) {
-                request->send(400, "text/plain", "Missing required BMS configuration fields");
+                request->send(400, "text/plain", "Campos obrigatórios de configuração do BMS ausentes");
                 return;
             }
 
             const uint8_t bmsType = doc["bmsType"].as<uint8_t>();
             if (bmsType > BmsTypeDaly) {
-                request->send(400, "text/plain", "BMS type is invalid");
+                request->send(400, "text/plain", "Tipo de BMS inválido");
                 return;
             }
 
@@ -409,20 +409,20 @@ void ControllerWebServer::startAP() {
 
             if (s.length() > 0) {
                 if (s.length() != 17) {
-                    request->send(400, "text/plain", "BMS MAC must be 17 characters (XX:XX:XX:XX:XX:XX)");
+                    request->send(400, "text/plain", "O MAC do BMS deve ter 17 caracteres (XX:XX:XX:XX:XX:XX)");
                     return;
                 }
                 for (int i = 0; i < 17; i++) {
                     if (i == 2 || i == 5 || i == 8 || i == 11 || i == 14) {
                         if (s[i] != ':') {
-                            request->send(400, "text/plain", "BMS MAC format: XX:XX:XX:XX:XX:XX");
+                            request->send(400, "text/plain", "Formato do MAC do BMS: XX:XX:XX:XX:XX:XX");
                             return;
                         }
                     } else {
                         const char c = s[i];
                         const bool hex = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
                         if (!hex) {
-                            request->send(400, "text/plain", "BMS MAC must use hex digits (0-9, A-F)");
+                            request->send(400, "text/plain", "O MAC do BMS deve usar dígitos hexadecimais (0-9, A-F)");
                             return;
                         }
                     }
@@ -430,7 +430,7 @@ void ControllerWebServer::startAP() {
             }
 
             if (bmsType != BmsTypeNone && s.length() != 17) {
-                request->send(400, "text/plain", "BMS MAC must be configured for the selected BMS type");
+                request->send(400, "text/plain", "O MAC do BMS deve ser configurado para o tipo de BMS selecionado");
                 return;
             }
 
@@ -438,7 +438,7 @@ void ControllerWebServer::startAP() {
             settings.setBmsMac(s.c_str());
             settings.save();
 
-            request->send(200, "text/plain", "Success: BMS configuration saved");
+            request->send(200, "text/plain", "Sucesso: Configurações do BMS salvas");
         },
         256
     );
@@ -450,21 +450,21 @@ void ControllerWebServer::startAP() {
         "/api/config/system",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             logWebHeap("/api/config/system POST");
-            if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
+            if (!checkPin(request)) { request->send(403, "text/plain", "PIN inválido"); return; }
             if (!json.is<JsonObject>()) {
-                request->send(400, "text/plain", "Invalid JSON: body must be an object");
+                request->send(400, "text/plain", "JSON inválido: o corpo deve ser um objeto");
                 return;
             }
 
             JsonObject doc = json.as<JsonObject>();
             if (!doc.containsKey("wifiAutoDisableAfterCalibration")) {
-                request->send(400, "text/plain", "Missing required system configuration fields");
+                request->send(400, "text/plain", "Campos obrigatórios de configuração do sistema ausentes");
                 return;
             }
 
             settings.setWifiAutoDisableAfterCalibration(doc["wifiAutoDisableAfterCalibration"].as<bool>());
             settings.save();
-            request->send(200, "text/plain", "Success: System configuration saved");
+            request->send(200, "text/plain", "Sucesso: Configurações do sistema salvas");
         },
         128
     );
@@ -479,7 +479,7 @@ void ControllerWebServer::startAP() {
         StaticJsonDocument<64> doc;
         doc["isDefault"] = (settings.getConfigPin() == "0000");
         if (doc.overflowed()) {
-            request->send(500, "text/plain", "JSON buffer overflow");
+            request->send(500, "text/plain", "Estouro do buffer JSON");
             return;
         }
         sendJsonResponse(request, 200, doc);
@@ -489,28 +489,28 @@ void ControllerWebServer::startAP() {
         "/api/config/pin",
         [](AsyncWebServerRequest *request, JsonVariant &json) {
             if (!json.is<JsonObject>()) {
-                request->send(400, "text/plain", "Invalid JSON");
+                request->send(400, "text/plain", "JSON inválido");
                 return;
             }
             JsonObject doc = json.as<JsonObject>();
             if (!doc.containsKey("currentPin") || !doc.containsKey("newPin")) {
-                request->send(400, "text/plain", "Missing currentPin or newPin");
+                request->send(400, "text/plain", "currentPin ou newPin ausente");
                 return;
             }
             const String currentPin = doc["currentPin"].as<const char*>();
             const String newPin     = doc["newPin"].as<const char*>();
             if (currentPin != settings.getConfigPin()) {
-                request->send(403, "text/plain", "Current PIN is incorrect");
+                request->send(403, "text/plain", "O PIN atual está incorreto");
                 return;
             }
             if (newPin.length() < 4 || newPin.length() > 8) {
-                request->send(400, "text/plain", "New PIN must be 4-8 characters");
+                request->send(400, "text/plain", "O novo PIN deve ter 4 a 8 caracteres");
                 return;
             }
             settings.setConfigPin(newPin);
             settings.save();
             ElegantOTA.setAuth("admin", settings.getConfigPin().c_str());
-            request->send(200, "text/plain", "PIN updated successfully");
+            request->send(200, "text/plain", "PIN atualizado com sucesso");
         },
         128
     );
@@ -584,7 +584,7 @@ void ControllerWebServer::startAP() {
         }
 
         if (doc.overflowed()) {
-            request->send(500, "text/plain", "JSON buffer overflow");
+            request->send(500, "text/plain", "Estouro do buffer JSON");
             return;
         }
 
@@ -702,19 +702,19 @@ void ControllerWebServer::startAP() {
             String filename = request->getParam("file")->value();
             // Security: reject path traversal and ensure absolute path
             if (filename.indexOf("..") >= 0) {
-                request->send(400, "text/plain", "Invalid path");
+                request->send(400, "text/plain", "Caminho inválido");
                 return;
             }
             if(!filename.startsWith("/")) filename = "/" + filename;
 
             if(LittleFS.exists(filename)){
                 LittleFS.remove(filename);
-                request->send(200, "text/plain", "Deleted");
+                request->send(200, "text/plain", "Excluído");
             } else {
-                request->send(404, "text/plain", "File not found");
+                request->send(404, "text/plain", "Arquivo não encontrado");
             }
         } else {
-            request->send(400, "text/plain", "Missing file param");
+            request->send(400, "text/plain", "Parâmetro de arquivo ausente");
         }
     });
 
@@ -722,7 +722,7 @@ void ControllerWebServer::startAP() {
         if (!checkPin(request)) { request->send(403, "text/plain", "Invalid PIN"); return; }
         File root = LittleFS.open("/");
         if (!root) {
-            request->send(500, "text/plain", "Filesystem error");
+            request->send(500, "text/plain", "Erro no sistema de arquivos");
             return;
         }
         std::vector<String> toDelete;
@@ -751,7 +751,7 @@ void ControllerWebServer::startAP() {
         HTTP_POST,
         [](AsyncWebServerRequest *request) {
             // This is the 'final' callback for the POST request, after file upload is complete.
-            request->send(200, "text/plain", (Update.hasError()) ? "Update failed!" : "Firmware update in progress. The device will reboot.");
+            request->send(200, "text/plain", (Update.hasError()) ? "Falha na atualização!" : "Atualização de firmware em andamento. O dispositivo será reiniciado.");
             if (!Update.hasError()) {
                 // If update was successful, ElegantOTA usually triggers reboot internally.
                 // If not, we explicitly restart here.

--- a/src/WebServer/Pages/CommonLayout.h
+++ b/src/WebServer/Pages/CommonLayout.h
@@ -27,11 +27,11 @@ inline String renderNavLink(const char* route, const char* label, const char* ac
 
 inline String renderTopbar(const char* activeRoute) {
     String html = "<div class=\"topbar\">";
-    html += renderNavLink("/", "Dashboard", activeRoute);
-    html += renderNavLink("/telemetry", "Telemetry", activeRoute);
+    html += renderNavLink("/", "Painel", activeRoute);
+    html += renderNavLink("/telemetry", "Telemetria", activeRoute);
     html += renderNavLink("/firmware", "Firmware", activeRoute);
-    html += renderNavLink("/logs-page", "Logs", activeRoute);
-    html += renderNavLink("/config", "Configuration", activeRoute);
+    html += renderNavLink("/logs-page", "Registros", activeRoute);
+    html += renderNavLink("/config", "Configurações", activeRoute);
     html += "</div>";
     return html;
 }

--- a/src/WebServer/Pages/ConfigBmsPage.h
+++ b/src/WebServer/Pages/ConfigBmsPage.h
@@ -6,7 +6,7 @@ static const char CONFIG_BMS_PAGE_HTML[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>
 <html>
 <head>
-    <title>FlyController - Bluetooth BMS</title>
+    <title>FlyController - BMS Bluetooth</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/config.css">
@@ -14,52 +14,52 @@ static const char CONFIG_BMS_PAGE_HTML[] PROGMEM = R"rawliteral(
 <body>
     <div class="page">
         <div class="topbar">
-            <a class="nav-btn" href="/">Dashboard</a>
-            <a class="nav-btn" href="/telemetry">Telemetry</a>
+            <a class="nav-btn" href="/">Painel</a>
+            <a class="nav-btn" href="/telemetry">Telemetria</a>
             <a class="nav-btn" href="/firmware">Firmware</a>
-            <a class="nav-btn" href="/logs-page">Logs</a>
-            <a class="nav-btn active" href="/config">Configuration</a>
+            <a class="nav-btn" href="/logs-page">Registros</a>
+            <a class="nav-btn active" href="/config">Configurações</a>
         </div>
 
         <div class="subnav">
-            <a class="nav-btn" href="/config/power">Power</a>
-            <a class="nav-btn" href="/config/thermal">Thermal</a>
+            <a class="nav-btn" href="/config/power">Energia</a>
+            <a class="nav-btn" href="/config/thermal">Térmica</a>
             <a class="nav-btn active" href="/config/bms">BMS</a>
-            <a class="nav-btn" href="/config/system">System</a>
+            <a class="nav-btn" href="/config/system">Sistema</a>
         </div>
 
         <div class="panel">
-            <h1>Bluetooth BMS</h1>
+            <h1>BMS Bluetooth</h1>
 
             <form id="bmsConfigForm">
                 <div class="form-group">
-                    <label for="bmsType">BMS type:</label>
+                    <label for="bmsType">Tipo de BMS:</label>
                     <select id="bmsType" name="bmsType">
-                        <option value="0">Disabled</option>
+                        <option value="0">Desativado</option>
                         <option value="1">JBD</option>
                         <option value="2">Daly (D2 BLE)</option>
                     </select>
-                    <div class="info-text">Select the Bluetooth BMS backend used by the controller.</div>
+                    <div class="info-text">Selecione o backend BMS Bluetooth usado pelo controlador.</div>
                 </div>
 
                 <div class="form-group">
-                    <label for="bmsMac">BMS Bluetooth address (MAC):</label>
+                    <label for="bmsMac">Endereço Bluetooth do BMS (MAC):</label>
                     <input type="text" id="bmsMac" name="bmsMac" maxlength="17" placeholder="A5:C2:39:2B:FC:4E">
-                    <div class="info-text">Format: XX:XX:XX:XX:XX:XX (6 hex bytes with colons).</div>
+                    <div class="info-text">Formato: XX:XX:XX:XX:XX:XX (6 bytes hex com dois-pontos).</div>
                 </div>
 
                 <div class="form-group">
-                    <button type="button" id="scanBmsButton">Scan for BMS</button>
-                    <div class="info-text" id="bmsScanStatus">Press "Scan for BMS" to search nearby JBD and Daly devices.</div>
+                    <button type="button" id="scanBmsButton">Buscar BMS</button>
+                    <div class="info-text" id="bmsScanStatus">Pressione "Buscar BMS" para procurar dispositivos JBD e Daly próximos.</div>
                     <div id="bmsScanResults" style="display: grid; gap: 10px; margin-top: 12px;"></div>
                 </div>
 
                 <div class="form-group">
                     <label for="configPin">PIN</label>
-                    <input type="password" id="configPin" maxlength="8" placeholder="Required to save">
+                    <input type="password" id="configPin" maxlength="8" placeholder="Necessário para salvar">
                 </div>
 
-                <button type="submit" id="saveButton">Save BMS Settings</button>
+                <button type="submit" id="saveButton">Salvar Configurações do BMS</button>
                 <div class="message" id="message"></div>
             </form>
         </div>
@@ -75,7 +75,7 @@ const $ = (id) => document.getElementById(id);
 const getPin = () => sessionStorage.getItem('cfgPin') || '';
 const setPin = (v) => sessionStorage.setItem('cfgPin', v);
 const BMS_TYPE_LABELS = {
-    0: 'Unknown',
+    0: 'Desconhecido',
     1: 'JBD',
     2: 'Daly (D2 BLE)'
 };
@@ -131,11 +131,11 @@ const renderBmsScanResults = (results) => {
         row.style.gap = '8px';
         row.innerHTML = `
             <div><strong>${escapeHtml(BMS_TYPE_LABELS[entry.detectedType] || 'Unknown')}</strong></div>
-            <div>${escapeHtml(entry.name || 'Unnamed device')}</div>
+            <div>${escapeHtml(entry.name || 'Dispositivo sem nome')}</div>
             <div>MAC: <code>${escapeHtml(entry.mac || '')}</code></div>
             <div>RSSI: ${typeof entry.rssi === 'number' ? entry.rssi + ' dBm' : 'N/A'}</div>
             <div>Services: <code>${escapeHtml(entry.advertisedServices || 'none')}</code></div>
-            <div><button type="button" class="use-bms-result" data-mac="${escapeHtml(entry.mac || '')}" data-type="${escapeHtml(entry.detectedType || 0)}">Use this BMS</button></div>
+            <div><button type="button" class="use-bms-result" data-mac="${escapeHtml(entry.mac || '')}" data-type="${escapeHtml(entry.detectedType || 0)}">Usar este BMS</button></div>
         `;
         container.appendChild(row);
     });
@@ -148,24 +148,24 @@ const renderBmsScanResults = (results) => {
             $('bmsMac').value = selectedMac;
             if (detectedType !== '0') {
                 $('bmsType').value = detectedType;
-                setBmsScanStatus('Selected scanned BMS. Review the detected type and save the configuration.');
+                setBmsScanStatus('BMS escaneado selecionado. Revise o tipo detectado e salve a configuração.');
             } else {
                 $('scanBmsButton').disabled = true;
-                setBmsScanStatus('Trying to detect the BMS type by connecting to the selected device...');
+                setBmsScanStatus('Tentando detectar o tipo de BMS conectando ao dispositivo selecionado...');
                 detectBmsType(selectedMac)
                     .then((data) => {
                         $('scanBmsButton').disabled = false;
                         if (data && Number(data.detectedType) > 0) {
                             $('bmsType').value = String(data.detectedType);
-                            setBmsScanStatus('BMS type detected after connection. Review the fields and save the configuration.');
+                            setBmsScanStatus('Tipo de BMS detectado após conexão. Revise os campos e salve a configuração.');
                         } else {
-                            setBmsScanStatus('Selected BLE device MAC. Type is still unknown after the connection test.');
+                            setBmsScanStatus('MAC do dispositivo BLE selecionado. Tipo ainda desconhecido após o teste de conexão.');
                         }
                     })
                     .catch((error) => {
                         console.error('Error detecting BMS type:', error);
                         $('scanBmsButton').disabled = false;
-                        setBmsScanStatus('Could not detect the BMS type after the connection test.');
+                        setBmsScanStatus('Não foi possível detectar o tipo de BMS após o teste de conexão.');
                     });
             }
         });
@@ -178,7 +178,7 @@ const applyBmsScanState = (data) => {
     $('scanBmsButton').disabled = isBusy;
 
     if (status === 'scanning') {
-        setBmsScanStatus('Scanning nearby BLE devices...');
+        setBmsScanStatus('Buscando dispositivos BLE próximos...');
         renderBmsScanResults(Array.isArray(data.results) ? data.results : []);
         scheduleBmsScanPolling();
         return;
@@ -187,7 +187,7 @@ const applyBmsScanState = (data) => {
     stopBmsScanPolling();
 
     if (status === 'error') {
-        setBmsScanStatus(data && data.error ? `Scan failed: ${data.error}` : 'Scan failed.');
+        setBmsScanStatus(data && data.error ? `Busca falhou: ${data.error}` : 'Busca falhou.');
         renderBmsScanResults([]);
         return;
     }
@@ -196,15 +196,15 @@ const applyBmsScanState = (data) => {
         const results = Array.isArray(data.results) ? data.results : [];
         renderBmsScanResults(results);
         if (results.length === 0) {
-            setBmsScanStatus('No BLE devices were found nearby.');
+            setBmsScanStatus('Nenhum dispositivo BLE encontrado nas proximidades.');
         } else {
-            setBmsScanStatus('Showing all BLE devices. Recognized JBD/Daly entries are labeled automatically.');
+            setBmsScanStatus('Exibindo todos os dispositivos BLE. Entradas JBD/Daly reconhecidas são rotuladas automaticamente.');
         }
         return;
     }
 
     renderBmsScanResults(Array.isArray(data && data.results) ? data.results : []);
-    setBmsScanStatus('Press "Scan for BMS" to search nearby BLE devices and inspect advertised services.');
+    setBmsScanStatus('Pressione "Buscar BMS" para procurar dispositivos BLE próximos e inspecionar os serviços anunciados.');
 };
 
 function loadBmsScanStatus() {
@@ -215,20 +215,20 @@ function loadBmsScanStatus() {
             console.error('Error loading BMS scan status:', error);
             stopBmsScanPolling();
             $('scanBmsButton').disabled = false;
-            setBmsScanStatus('Unable to read BLE scan status.');
+            setBmsScanStatus('Não foi possível ler o status da busca BLE.');
         });
 }
 
 const startBmsScan = () => {
     $('scanBmsButton').disabled = true;
-    setBmsScanStatus('Starting BLE scan...');
+    setBmsScanStatus('Iniciando busca BLE...');
     fetch('/api/bms/scan/start', { method: 'POST', headers: { 'X-Config-Pin': getPin() } })
         .then((response) => response.json())
         .then(applyBmsScanState)
         .catch((error) => {
             console.error('Error starting BMS scan:', error);
             $('scanBmsButton').disabled = false;
-            setBmsScanStatus('Unable to start BLE scan.');
+            setBmsScanStatus('Não foi possível iniciar a busca BLE.');
         });
 };
 
@@ -249,7 +249,7 @@ const loadCurrentValues = () => {
         })
         .catch((error) => {
             console.error('Error loading BMS settings:', error);
-            showMessage('Error loading current configuration', 'err');
+            showMessage('Erro ao carregar a configuração atual', 'err');
         });
 };
 
@@ -266,7 +266,7 @@ $('bmsConfigForm').addEventListener('submit', function(e) {
     const bmsMac = $('bmsMac').value.trim();
 
     if (bmsType !== 0 && !/^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/.test(bmsMac)) {
-        showMessage('BMS MAC must be in format XX:XX:XX:XX:XX:XX', 'err');
+        showMessage('O MAC do BMS deve estar no formato XX:XX:XX:XX:XX:XX', 'err');
         saveButton.disabled = false;
         return;
     }
@@ -284,11 +284,11 @@ $('bmsConfigForm').addEventListener('submit', function(e) {
     })
         .then((response) => response.text().then((text) => ({ ok: response.ok, text })))
         .then(({ ok, text }) => {
-            showMessage(ok ? 'BMS settings saved successfully!' : 'Error saving configuration: ' + text, ok ? 'ok' : 'err');
+            showMessage(ok ? 'Configurações do BMS salvas com sucesso!' : 'Erro ao salvar a configuração: ' + text, ok ? 'ok' : 'err');
             saveButton.disabled = false;
         })
         .catch((error) => {
-            showMessage('Error saving configuration: ' + error, 'err');
+            showMessage('Erro ao salvar a configuração: ' + error, 'err');
             saveButton.disabled = false;
         });
 });

--- a/src/WebServer/Pages/ConfigHubPage.h
+++ b/src/WebServer/Pages/ConfigHubPage.h
@@ -5,36 +5,36 @@
 inline String renderConfigHubPage() {
     const char* body = R"rawliteral(
 <div class="panel">
-    <h1>Configuration</h1>
-    <div class="sub">Choose a section to configure the controller.</div>
+    <h1>Configurações</h1>
+    <div class="sub">Escolha uma seção para configurar o controlador.</div>
 </div>
 
 <div class="grid">
     <a class="card link-card" href="/config/power">
-        <div class="label">Battery & Power</div>
-        <div class="value">Power</div>
-        <div class="sub">Battery capacity, voltage limits, power control, and throttle response.</div>
+        <div class="label">Bateria e Energia</div>
+        <div class="value">Energia</div>
+        <div class="sub">Capacidade da bateria, limites de tensão, controle de energia e resposta do acelerador.</div>
     </a>
     <a class="card link-card" href="/config/thermal">
-        <div class="label">Thermal Protection</div>
-        <div class="value">Thermal</div>
-        <div class="sub">Motor and ESC protection thresholds and power reduction points.</div>
+        <div class="label">Proteção Térmica</div>
+        <div class="value">Térmica</div>
+        <div class="sub">Limites de proteção do motor e do ESC e pontos de redução de energia.</div>
     </a>
     <a class="card link-card" href="/config/bms">
-        <div class="label">Bluetooth BMS</div>
+        <div class="label">BMS Bluetooth</div>
         <div class="value">BMS</div>
-        <div class="sub">BMS type, Bluetooth address, and BLE device tools.</div>
+        <div class="sub">Tipo de BMS, endereço Bluetooth e ferramentas de dispositivo BLE.</div>
     </a>
     <a class="card link-card" href="/config/system">
-        <div class="label">Device Behavior</div>
-        <div class="value">System</div>
-        <div class="sub">Wi-Fi behavior and small system-level options.</div>
+        <div class="label">Comportamento do Dispositivo</div>
+        <div class="value">Sistema</div>
+        <div class="sub">Comportamento do Wi-Fi e opções gerais do sistema.</div>
     </a>
 </div>
 )rawliteral";
 
     PageSpec spec = {
-        "FlyController - Configuration",
+        "FlyController - Configurações",
         "/config",
         body,
         nullptr,

--- a/src/WebServer/Pages/ConfigPowerPage.h
+++ b/src/WebServer/Pages/ConfigPowerPage.h
@@ -6,7 +6,7 @@ static const char CONFIG_POWER_PAGE_HTML[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>
 <html>
 <head>
-    <title>FlyController - Battery & Power</title>
+    <title>FlyController - Bateria e Energia</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/config.css">
@@ -14,76 +14,76 @@ static const char CONFIG_POWER_PAGE_HTML[] PROGMEM = R"rawliteral(
 <body>
     <div class="page">
         <div class="topbar">
-            <a class="nav-btn" href="/">Dashboard</a>
-            <a class="nav-btn" href="/telemetry">Telemetry</a>
+            <a class="nav-btn" href="/">Painel</a>
+            <a class="nav-btn" href="/telemetry">Telemetria</a>
             <a class="nav-btn" href="/firmware">Firmware</a>
-            <a class="nav-btn" href="/logs-page">Logs</a>
-            <a class="nav-btn active" href="/config">Configuration</a>
+            <a class="nav-btn" href="/logs-page">Registros</a>
+            <a class="nav-btn active" href="/config">Configurações</a>
         </div>
 
         <div class="subnav">
-            <a class="nav-btn active" href="/config/power">Power</a>
-            <a class="nav-btn" href="/config/thermal">Thermal</a>
+            <a class="nav-btn active" href="/config/power">Energia</a>
+            <a class="nav-btn" href="/config/thermal">Térmica</a>
             <a class="nav-btn" href="/config/bms">BMS</a>
-            <a class="nav-btn" href="/config/system">System</a>
+            <a class="nav-btn" href="/config/system">Sistema</a>
         </div>
 
         <div class="panel">
-            <h1>Battery & Power</h1>
+            <h1>Bateria e Energia</h1>
 
             <form id="powerConfigForm">
-                <h2>Battery Settings</h2>
+                <h2>Configurações de Bateria</h2>
 
                 <div class="form-group">
-                    <label for="batteryCapacity">Battery Capacity (Ah):</label>
+                    <label for="batteryCapacity">Capacidade da Bateria (Ah):</label>
                     <select id="batteryCapacity" name="batteryCapacity">
                         <option value="18">18 Ah</option>
                         <option value="34">34 Ah</option>
                         <option value="65">65 Ah</option>
-                        <option value="custom">Custom (enter value)</option>
+                        <option value="custom">Personalizado (inserir valor)</option>
                     </select>
-                    <input type="number" id="batteryCapacityCustom" name="batteryCapacityCustom" min="1" max="200" step="0.1" placeholder="Enter capacity in Ah" style="display: none; margin-top: 10px;">
-                    <div class="info-text">Select from preset values or choose custom to enter your own capacity.</div>
+                    <input type="number" id="batteryCapacityCustom" name="batteryCapacityCustom" min="1" max="200" step="0.1" placeholder="Inserir capacidade em Ah" style="display: none; margin-top: 10px;">
+                    <div class="info-text">Selecione um valor predefinido ou escolha personalizado para inserir sua própria capacidade.</div>
                 </div>
 
                 <div class="form-group">
-                    <label for="minVoltagePerCell">Minimum Voltage per Cell (V):</label>
+                    <label for="minVoltagePerCell">Tensão Mínima por Célula (V):</label>
                     <input type="number" id="minVoltagePerCell" name="minVoltagePerCell" min="2.5" max="4.5" step="0.01" required>
-                    <div class="info-text">Minimum safe voltage per cell (typically 3.0V - 3.15V for LiPo).</div>
-                    <div class="total-voltage">Total: <span id="minVoltageTotalValue">0.00</span> V (14 cells)</div>
+                    <div class="info-text">Tensão mínima segura por célula (normalmente 3,0V - 3,15V para LiPo).</div>
+                    <div class="total-voltage">Total: <span id="minVoltageTotalValue">0.00</span> V (14 células)</div>
                 </div>
 
                 <div class="form-group">
-                    <label for="maxVoltagePerCell">Maximum Voltage per Cell (V):</label>
+                    <label for="maxVoltagePerCell">Tensão Máxima por Célula (V):</label>
                     <input type="number" id="maxVoltagePerCell" name="maxVoltagePerCell" min="2.5" max="4.5" step="0.01" required>
-                    <div class="info-text">Maximum safe voltage per cell (typically 4.1V - 4.2V for LiPo).</div>
-                    <div class="total-voltage">Total: <span id="maxVoltageTotalValue">0.00</span> V (14 cells)</div>
+                    <div class="info-text">Tensão máxima segura por célula (normalmente 4,1V - 4,2V para LiPo).</div>
+                    <div class="total-voltage">Total: <span id="maxVoltageTotalValue">0.00</span> V (14 células)</div>
                 </div>
 
-                <h2>Power Control Settings</h2>
+                <h2>Configurações de Controle de Energia</h2>
 
                 <div class="form-group">
                     <label for="powerControlEnabled" style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
                         <input type="checkbox" id="powerControlEnabled" name="powerControlEnabled" style="width: auto;">
-                        <span>Enable Power Control</span>
+                        <span>Ativar Controle de Energia</span>
                     </label>
-                    <div class="info-text">When enabled, power output is limited based on battery voltage, motor temperature, and ESC temperature. When disabled, full power is available without limitations.</div>
+                    <div class="info-text">Quando ativado, a saída de energia é limitada com base na tensão da bateria, temperatura do motor e temperatura do ESC. Quando desativado, a energia total está disponível sem limitações.</div>
                 </div>
 
-                <h2>Throttle Response</h2>
+                <h2>Resposta do Acelerador</h2>
 
                 <div class="form-group">
-                    <label for="throttleCurveGamma">Throttle curve (gamma):</label>
+                    <label for="throttleCurveGamma">Curva do acelerador (gamma):</label>
                     <input type="number" id="throttleCurveGamma" name="throttleCurveGamma" min="1" max="3" step="0.1" required>
-                    <div class="info-text">Power-law curve: 1.0 = linear; higher values = less sensitive at low throttle, more responsive at high throttle.</div>
+                    <div class="info-text">Curva de potência: 1,0 = linear; valores maiores = menos sensível em aceleração baixa, mais responsivo em aceleração alta.</div>
                 </div>
 
                 <div class="form-group">
                     <label for="configPin">PIN</label>
-                    <input type="password" id="configPin" maxlength="8" placeholder="Required to save">
+                    <input type="password" id="configPin" maxlength="8" placeholder="Necessário para salvar">
                 </div>
 
-                <button type="submit" id="saveButton">Save Power Settings</button>
+                <button type="submit" id="saveButton">Salvar Configurações de Energia</button>
                 <div class="message" id="message"></div>
             </form>
         </div>
@@ -137,7 +137,7 @@ const loadCurrentValues = () => {
         })
         .catch((error) => {
             console.error('Error loading power settings:', error);
-            showMessage('Error loading current configuration', 'err');
+            showMessage('Erro ao carregar a configuração atual', 'err');
         });
 };
 
@@ -165,7 +165,7 @@ $('powerConfigForm').addEventListener('submit', function(e) {
         : parseFloat($('batteryCapacity').value);
 
     if (!capacityAh || capacityAh < 1 || capacityAh > 200) {
-        showMessage('Battery capacity must be between 1 and 200 Ah', 'err');
+        showMessage('A capacidade da bateria deve ser entre 1 e 200 Ah', 'err');
         saveButton.disabled = false;
         return;
     }
@@ -175,7 +175,7 @@ $('powerConfigForm').addEventListener('submit', function(e) {
     const throttleCurveGamma = parseFloat($('throttleCurveGamma').value);
 
     if (isNaN(throttleCurveGamma) || throttleCurveGamma < 1 || throttleCurveGamma > 3) {
-        showMessage('Throttle curve gamma must be between 1.0 and 3.0', 'err');
+        showMessage('O gamma da curva do acelerador deve ser entre 1,0 e 3,0', 'err');
         saveButton.disabled = false;
         return;
     }
@@ -198,11 +198,11 @@ $('powerConfigForm').addEventListener('submit', function(e) {
     })
         .then((response) => response.text().then((text) => ({ ok: response.ok, text })))
         .then(({ ok, text }) => {
-            showMessage(ok ? 'Power settings saved successfully!' : 'Error saving configuration: ' + text, ok ? 'ok' : 'err');
+            showMessage(ok ? 'Configurações de energia salvas com sucesso!' : 'Erro ao salvar a configuração: ' + text, ok ? 'ok' : 'err');
             saveButton.disabled = false;
         })
         .catch((error) => {
-            showMessage('Error saving configuration: ' + error, 'err');
+            showMessage('Erro ao salvar a configuração: ' + error, 'err');
             saveButton.disabled = false;
         });
 });

--- a/src/WebServer/Pages/ConfigSystemPage.h
+++ b/src/WebServer/Pages/ConfigSystemPage.h
@@ -6,7 +6,7 @@ static const char CONFIG_SYSTEM_PAGE_HTML[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>
 <html>
 <head>
-    <title>FlyController - System</title>
+    <title>FlyController - Sistema</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/config.css">
@@ -14,38 +14,38 @@ static const char CONFIG_SYSTEM_PAGE_HTML[] PROGMEM = R"rawliteral(
 <body>
     <div class="page">
         <div class="topbar">
-            <a class="nav-btn" href="/">Dashboard</a>
-            <a class="nav-btn" href="/telemetry">Telemetry</a>
+            <a class="nav-btn" href="/">Painel</a>
+            <a class="nav-btn" href="/telemetry">Telemetria</a>
             <a class="nav-btn" href="/firmware">Firmware</a>
-            <a class="nav-btn" href="/logs-page">Logs</a>
-            <a class="nav-btn active" href="/config">Configuration</a>
+            <a class="nav-btn" href="/logs-page">Registros</a>
+            <a class="nav-btn active" href="/config">Configurações</a>
         </div>
 
         <div class="subnav">
-            <a class="nav-btn" href="/config/power">Power</a>
-            <a class="nav-btn" href="/config/thermal">Thermal</a>
+            <a class="nav-btn" href="/config/power">Energia</a>
+            <a class="nav-btn" href="/config/thermal">Térmica</a>
             <a class="nav-btn" href="/config/bms">BMS</a>
-            <a class="nav-btn active" href="/config/system">System</a>
+            <a class="nav-btn active" href="/config/system">Sistema</a>
         </div>
 
         <div class="panel">
-            <h1>System</h1>
+            <h1>Sistema</h1>
 
             <form id="systemConfigForm">
                 <div class="form-group">
                     <label for="wifiAutoDisableAfterCalibration" style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
                         <input type="checkbox" id="wifiAutoDisableAfterCalibration" name="wifiAutoDisableAfterCalibration" style="width: auto;">
-                        <span>Disable Wi-Fi after throttle calibration</span>
+                        <span>Desativar Wi-Fi após calibração do acelerador</span>
                     </label>
-                    <div class="info-text">When enabled, access point and web server are stopped automatically after throttle calibration completes.</div>
+                    <div class="info-text">Quando ativado, o ponto de acesso e o servidor web são encerrados automaticamente após a conclusão da calibração do acelerador.</div>
                 </div>
 
                 <div class="form-group">
                     <label for="configPin">PIN</label>
-                    <input type="password" id="configPin" maxlength="8" placeholder="Required to save">
+                    <input type="password" id="configPin" maxlength="8" placeholder="Necessário para salvar">
                 </div>
 
-                <button type="submit" id="saveButton">Save System Settings</button>
+                <button type="submit" id="saveButton">Salvar Configurações do Sistema</button>
                 <div class="message" id="message"></div>
             </form>
         </div>
@@ -77,7 +77,7 @@ const loadCurrentValues = () => {
         })
         .catch((error) => {
             console.error('Error loading system settings:', error);
-            showMessage('Error loading current configuration', 'err');
+            showMessage('Erro ao carregar a configuração atual', 'err');
         });
 };
 
@@ -100,11 +100,11 @@ $('systemConfigForm').addEventListener('submit', function(e) {
     })
         .then((response) => response.text().then((text) => ({ ok: response.ok, text })))
         .then(({ ok, text }) => {
-            showMessage(ok ? 'System settings saved successfully!' : 'Error saving configuration: ' + text, ok ? 'ok' : 'err');
+            showMessage(ok ? 'Configurações do sistema salvas com sucesso!' : 'Erro ao salvar a configuração: ' + text, ok ? 'ok' : 'err');
             saveButton.disabled = false;
         })
         .catch((error) => {
-            showMessage('Error saving configuration: ' + error, 'err');
+            showMessage('Erro ao salvar a configuração: ' + error, 'err');
             saveButton.disabled = false;
         });
 });

--- a/src/WebServer/Pages/ConfigThermalPage.h
+++ b/src/WebServer/Pages/ConfigThermalPage.h
@@ -6,7 +6,7 @@ static const char CONFIG_THERMAL_PAGE_HTML[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>
 <html>
 <head>
-    <title>FlyController - Thermal Protection</title>
+    <title>FlyController - Proteção Térmica</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/config.css">
@@ -14,58 +14,58 @@ static const char CONFIG_THERMAL_PAGE_HTML[] PROGMEM = R"rawliteral(
 <body>
     <div class="page">
         <div class="topbar">
-            <a class="nav-btn" href="/">Dashboard</a>
-            <a class="nav-btn" href="/telemetry">Telemetry</a>
+            <a class="nav-btn" href="/">Painel</a>
+            <a class="nav-btn" href="/telemetry">Telemetria</a>
             <a class="nav-btn" href="/firmware">Firmware</a>
-            <a class="nav-btn" href="/logs-page">Logs</a>
-            <a class="nav-btn active" href="/config">Configuration</a>
+            <a class="nav-btn" href="/logs-page">Registros</a>
+            <a class="nav-btn active" href="/config">Configurações</a>
         </div>
 
         <div class="subnav">
-            <a class="nav-btn" href="/config/power">Power</a>
-            <a class="nav-btn active" href="/config/thermal">Thermal</a>
+            <a class="nav-btn" href="/config/power">Energia</a>
+            <a class="nav-btn active" href="/config/thermal">Térmica</a>
             <a class="nav-btn" href="/config/bms">BMS</a>
-            <a class="nav-btn" href="/config/system">System</a>
+            <a class="nav-btn" href="/config/system">Sistema</a>
         </div>
 
         <div class="panel">
-            <h1>Thermal Protection</h1>
+            <h1>Proteção Térmica</h1>
 
             <form id="thermalConfigForm">
-                <h2>Motor Temperature Settings</h2>
+                <h2>Configurações de Temperatura do Motor</h2>
 
                 <div class="form-group">
-                    <label for="motorMaxTemp">Maximum Motor Temperature (C):</label>
+                    <label for="motorMaxTemp">Temperatura Máxima do Motor (C):</label>
                     <input type="number" id="motorMaxTemp" name="motorMaxTemp" min="0" max="150" step="1" required>
-                    <div class="info-text">Motor will be completely disabled at this temperature.</div>
+                    <div class="info-text">O motor será completamente desligado nesta temperatura.</div>
                 </div>
 
                 <div class="form-group">
-                    <label for="motorTempReductionStart">Motor Temperature Reduction Start (C):</label>
+                    <label for="motorTempReductionStart">Início da Redução de Temperatura do Motor (C):</label>
                     <input type="number" id="motorTempReductionStart" name="motorTempReductionStart" min="0" max="150" step="1" required>
-                    <div class="info-text">Power reduction begins at this temperature and increases linearly until maximum temperature.</div>
+                    <div class="info-text">A redução de energia começa nesta temperatura e aumenta linearmente até a temperatura máxima.</div>
                 </div>
 
-                <h2>ESC Temperature Settings</h2>
+                <h2>Configurações de Temperatura do ESC</h2>
 
                 <div class="form-group">
-                    <label for="escMaxTemp">Maximum ESC Temperature (C):</label>
+                    <label for="escMaxTemp">Temperatura Máxima do ESC (C):</label>
                     <input type="number" id="escMaxTemp" name="escMaxTemp" min="0" max="150" step="1" required>
-                    <div class="info-text">ESC will be completely disabled at this temperature.</div>
+                    <div class="info-text">O ESC será completamente desligado nesta temperatura.</div>
                 </div>
 
                 <div class="form-group">
-                    <label for="escTempReductionStart">ESC Temperature Reduction Start (C):</label>
+                    <label for="escTempReductionStart">Início da Redução de Temperatura do ESC (C):</label>
                     <input type="number" id="escTempReductionStart" name="escTempReductionStart" min="0" max="150" step="1" required>
-                    <div class="info-text">Power reduction begins at this temperature and increases linearly until maximum temperature.</div>
+                    <div class="info-text">A redução de energia começa nesta temperatura e aumenta linearmente até a temperatura máxima.</div>
                 </div>
 
                 <div class="form-group">
                     <label for="configPin">PIN</label>
-                    <input type="password" id="configPin" maxlength="8" placeholder="Required to save">
+                    <input type="password" id="configPin" maxlength="8" placeholder="Necessário para salvar">
                 </div>
 
-                <button type="submit" id="saveButton">Save Thermal Settings</button>
+                <button type="submit" id="saveButton">Salvar Configurações Térmicas</button>
                 <div class="message" id="message"></div>
             </form>
         </div>
@@ -100,7 +100,7 @@ const loadCurrentValues = () => {
         })
         .catch((error) => {
             console.error('Error loading thermal settings:', error);
-            showMessage('Error loading current configuration', 'err');
+            showMessage('Erro ao carregar a configuração atual', 'err');
         });
 };
 
@@ -128,11 +128,11 @@ $('thermalConfigForm').addEventListener('submit', function(e) {
     })
         .then((response) => response.text().then((text) => ({ ok: response.ok, text })))
         .then(({ ok, text }) => {
-            showMessage(ok ? 'Thermal settings saved successfully!' : 'Error saving configuration: ' + text, ok ? 'ok' : 'err');
+            showMessage(ok ? 'Configurações térmicas salvas com sucesso!' : 'Erro ao salvar a configuração: ' + text, ok ? 'ok' : 'err');
             saveButton.disabled = false;
         })
         .catch((error) => {
-            showMessage('Error saving configuration: ' + error, 'err');
+            showMessage('Erro ao salvar a configuração: ' + error, 'err');
             saveButton.disabled = false;
         });
 });

--- a/src/WebServer/Pages/DashboardPage.h
+++ b/src/WebServer/Pages/DashboardPage.h
@@ -5,28 +5,28 @@
 inline String renderDashboardPage() {
     const char* body = R"rawliteral(
 <div class="panel">
-    <h1>FlyController Dashboard</h1>
-    <div class="sub">Quick access and basic device status</div>
+    <h1>FlyController Painel</h1>
+    <div class="sub">Acesso rápido e status básico do dispositivo</div>
 </div>
 
 <div class="grid">
     <div class="card">
-        <div class="label">Firmware Version</div>
+        <div class="label">Versão do Firmware</div>
         <div class="value">%APP_VERSION%</div>
         <div class="sub">Build: %BUILD_DATE% %BUILD_TIME%</div>
     </div>
     <div class="card">
-        <div class="label">Controller Type</div>
+        <div class="label">Tipo de Controlador</div>
         <div class="value">%CONTROLLER%</div>
-        <div class="sub">Uptime: <span id="uptime">--</span></div>
+        <div class="sub">Tempo ligado: <span id="uptime">--</span></div>
     </div>
     <div class="card">
-        <div class="label">Battery Voltage</div>
+        <div class="label">Tensão da Bateria</div>
         <div class="value" id="batteryVoltage">--</div>
-        <div class="sub">Telemetry freshness: <span id="freshness">--</span></div>
+        <div class="sub">Telemetria: <span id="freshness">--</span></div>
     </div>
     <div class="card">
-        <div class="label">System Status</div>
+        <div class="label">Status do Sistema</div>
         <div class="value" id="armed">--</div>
         <div class="sub" id="telemetryState">--</div>
     </div>
@@ -40,19 +40,19 @@ function loadDashboard() {
     fetchJson('/api/telemetry')
         .then((d) => {
             setText('batteryVoltage', formatVoltage(d.batteryVoltageMv || 0));
-            setText('armed', d.armed ? 'ARMED' : 'DISARMED');
+            setText('armed', d.armed ? 'ARMADO' : 'DESARMADO');
             setText('uptime', `${Math.floor((d.uptimeMs || 0) / 1000)} s`);
             if (!d.hasTelemetry) {
-                setText('telemetryState', 'No telemetry data');
+                setText('telemetryState', 'Sem dados de telemetria');
                 setText('freshness', '--');
                 return;
             }
             const age = Math.max(0, (d.uptimeMs || 0) - (d.lastTelemetryUpdateMs || 0));
-            setText('telemetryState', age > 3000 ? 'STALE' : 'LIVE');
+            setText('telemetryState', age > 3000 ? 'DESATUALIZADO' : 'AO VIVO');
             setText('freshness', `${age} ms`);
         })
         .catch(() => {
-            setText('telemetryState', 'Unavailable');
+            setText('telemetryState', 'Indisponível');
         });
 }
 
@@ -61,7 +61,7 @@ setInterval(loadDashboard, 1000);
 )rawliteral";
 
     PageSpec spec = {
-        "FlyController Dashboard",
+        "FlyController Painel",
         "/",
         body,
         nullptr,

--- a/src/WebServer/Pages/FirmwarePage.h
+++ b/src/WebServer/Pages/FirmwarePage.h
@@ -28,7 +28,7 @@ $('fwForm').addEventListener('submit', function(e) {
         .then((r) => r.text())
         .then((text) => {
             responseDiv.textContent = text;
-            responseDiv.classList.add(text.includes('Success') || text.includes('progress') ? 'ok' : 'err');
+            responseDiv.classList.add(text.includes('Sucesso') || text.includes('andamento') ? 'ok' : 'err');
         })
         .catch((err) => {
             responseDiv.textContent = `Erro: ${err}`;

--- a/src/WebServer/Pages/FirmwarePage.h
+++ b/src/WebServer/Pages/FirmwarePage.h
@@ -5,11 +5,11 @@
 inline String renderFirmwarePage() {
     const char* body = R"rawliteral(
 <div class="panel">
-    <h1>Firmware Update</h1>
-    <p>Select a <code>.bin</code> file to update the device.</p>
+    <h1>Atualização de Firmware</h1>
+    <p>Selecione um arquivo <code>.bin</code> para atualizar o dispositivo.</p>
     <form id="fwForm">
         <input type="file" name="update" accept=".bin">
-        <button type="submit">Update Firmware</button>
+        <button type="submit">Atualizar Firmware</button>
     </form>
     <div id="response" class="message"></div>
 </div>
@@ -20,7 +20,7 @@ $('fwForm').addEventListener('submit', function(e) {
     e.preventDefault();
     const formData = new FormData(e.target);
     const responseDiv = $('response');
-    responseDiv.textContent = 'Updating...';
+    responseDiv.textContent = 'Atualizando...';
     responseDiv.className = 'message';
     responseDiv.style.display = 'block';
 
@@ -31,7 +31,7 @@ $('fwForm').addEventListener('submit', function(e) {
             responseDiv.classList.add(text.includes('Success') || text.includes('progress') ? 'ok' : 'err');
         })
         .catch((err) => {
-            responseDiv.textContent = `Error: ${err}`;
+            responseDiv.textContent = `Erro: ${err}`;
             responseDiv.classList.add('err');
         });
 });

--- a/src/WebServer/Pages/LogsPage.h
+++ b/src/WebServer/Pages/LogsPage.h
@@ -5,19 +5,19 @@
 inline String renderLogsPage() {
     const char* body = R"rawliteral(
 <div class="panel">
-    <h1>Data Logs</h1>
+    <h1>Registros de Dados</h1>
     <div class="form-group" style="max-width:320px;margin-bottom:1rem;">
         <label for="logPin">PIN</label>
-        <input type="password" id="logPin" maxlength="8" placeholder="Required to delete" oninput="setPin(this.value)">
+        <input type="password" id="logPin" maxlength="8" placeholder="Necessário para excluir" oninput="setPin(this.value)">
     </div>
     <div class="table-wrap">
         <table id="fileTable">
-            <thead><tr><th>File</th><th>Size</th><th>Action</th></tr></thead>
-            <tbody><tr><td colspan="3">Loading...</td></tr></tbody>
+            <thead><tr><th>Arquivo</th><th>Tamanho</th><th>Ação</th></tr></thead>
+            <tbody><tr><td colspan="3">Carregando...</td></tr></tbody>
         </table>
     </div>
     <div class="panel-footer" style="margin-top:1rem;">
-        <button type="button" id="deleteAllBtn" class="btn btn-red" disabled onclick="deleteAllLogs()">Delete all logs</button>
+        <button type="button" id="deleteAllBtn" class="btn btn-red" disabled onclick="deleteAllLogs()">Excluir todos os registros</button>
     </div>
 </div>
 )rawliteral";
@@ -32,7 +32,7 @@ const loadFiles = () => {
             const deleteAllBtn = document.querySelector('#deleteAllBtn');
             tbody.innerHTML = '';
             if (files.length === 0) {
-                tbody.innerHTML = '<tr><td colspan="3">No logs found.</td></tr>';
+                tbody.innerHTML = '<tr><td colspan="3">Nenhum registro encontrado.</td></tr>';
                 if (deleteAllBtn) deleteAllBtn.disabled = true;
                 return;
             }
@@ -46,31 +46,31 @@ const loadFiles = () => {
                     <td>${displayName}</td>
                     <td>${formatBytes(f.size)}</td>
                     <td>
-                        <a class="btn btn-sm btn-green" href="/logs${f.name}" download="${downloadName}">Download CSV</a>
-                        <button class="btn btn-sm btn-red" onclick="deleteFile('${f.name}')">Delete</button>
+                        <a class="btn btn-sm btn-green" href="/logs${f.name}" download="${downloadName}">Baixar CSV</a>
+                        <button class="btn btn-sm btn-red" onclick="deleteFile('${f.name}')">Excluir</button>
                     </td>`;
                 tbody.appendChild(tr);
             });
         })
         .catch(() => {
-            document.querySelector('#fileTable tbody').innerHTML = '<tr><td colspan="3">Error loading files.</td></tr>';
+            document.querySelector('#fileTable tbody').innerHTML = '<tr><td colspan="3">Erro ao carregar arquivos.</td></tr>';
             const deleteAllBtn = document.querySelector('#deleteAllBtn');
             if (deleteAllBtn) deleteAllBtn.disabled = true;
         });
 };
 
 const deleteFile = (filename) => {
-    if (!confirm(`Delete ${filename}?`)) return;
+    if (!confirm(`Excluir ${filename}?`)) return;
     fetchWithPin('/delete?file=' + encodeURIComponent(filename))
-        .then((r) => r.ok ? loadFiles() : r.text().then((t) => alert('Delete failed: ' + t)));
+        .then((r) => r.ok ? loadFiles() : r.text().then((t) => alert('Falha ao excluir: ' + t)));
 };
 
 const deleteAllLogs = () => {
     const deleteAllBtn = document.querySelector('#deleteAllBtn');
     if (deleteAllBtn && deleteAllBtn.disabled) return;
-    if (!confirm('This will permanently delete all log files on the device. Continue?')) return;
+    if (!confirm('Isso excluirá permanentemente todos os arquivos de registro do dispositivo. Continuar?')) return;
     fetchWithPin('/delete-all-logs')
-        .then((r) => r.ok ? loadFiles() : r.text().then((t) => alert('Delete failed: ' + t)));
+        .then((r) => r.ok ? loadFiles() : r.text().then((t) => alert('Falha ao excluir: ' + t)));
 };
 
 // Pre-fill PIN from sessionStorage on page load
@@ -83,7 +83,7 @@ loadFiles();
 )rawliteral";
 
     PageSpec spec = {
-        "FlyController - Logs",
+        "FlyController - Registros",
         "/logs-page",
         body,
         nullptr,

--- a/src/WebServer/Pages/TelemetryPage.h
+++ b/src/WebServer/Pages/TelemetryPage.h
@@ -6,7 +6,7 @@ static const char TELEMETRY_PAGE_HTML[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>
 <html>
 <head>
-    <title>FlyController - Telemetry</title>
+    <title>FlyController - Telemetria</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b74de">
@@ -17,52 +17,52 @@ static const char TELEMETRY_PAGE_HTML[] PROGMEM = R"rawliteral(
 <body class="telemetry-page">
     <div class="page page-telemetry">
         <div class="topbar">
-            <a class="nav-btn" href="/">Dashboard</a>
-            <a class="nav-btn active" href="/telemetry">Telemetry</a>
+            <a class="nav-btn" href="/">Painel</a>
+            <a class="nav-btn active" href="/telemetry">Telemetria</a>
             <a class="nav-btn" href="/firmware">Firmware</a>
-            <a class="nav-btn" href="/logs-page">Logs</a>
-            <a class="nav-btn" href="/config">Configuration</a>
+            <a class="nav-btn" href="/logs-page">Registros</a>
+            <a class="nav-btn" href="/config">Configurações</a>
         </div>
 
         <div class="telemetry-shell">
             <div class="telemetry-hero-grid">
                 <div class="panel telemetry-header hero-card">
                     <div class="telemetry-header-copy">
-                        <h1>Live Telemetry</h1>
-                        <div class="hero-main">Data status: <span id="statusBadge" class="status nodata">NO DATA</span></div>
+                        <h1>Telemetria ao Vivo</h1>
+                        <div class="hero-main">Status dos dados: <span id="statusBadge" class="status nodata">SEM DADOS</span></div>
                     </div>
                 </div>
 
                 <div class="panel wake-card hero-card">
-                    <h2>Keep Screen On</h2>
+                    <h2>Manter Tela Ligada</h2>
                     <div class="hero-actions">
-                        <span id="wakeStatusBadge" class="status status-secondary">INACTIVE</span>
+                        <span id="wakeStatusBadge" class="status status-secondary">INATIVO</span>
                         <button type="button" id="wakeHelpToggle" class="help-button" aria-expanded="false" aria-controls="wakeHelp">?</button>
                     </div>
                     <div class="hero-actions">
-                        <button type="button" id="wakeToggleButton" class="btn btn-sm wake-button">Keep Awake</button>
+                        <button type="button" id="wakeToggleButton" class="btn btn-sm wake-button">Manter Ativo</button>
                     </div>
-                    <div class="help-panel" id="wakeHelp">The page will try automatically first. If the screen still turns off, tap the button once.</div>
+                    <div class="help-panel" id="wakeHelp">A página tentará automaticamente primeiro. Se a tela ainda apagar, toque no botão uma vez.</div>
                 </div>
             </div>
 
             <div class="grid telemetry-grid">
                 <div class="card">
-                    <div class="label">Battery Voltage</div>
+                    <div class="label">Tensão da Bateria</div>
                     <div class="value" id="batteryVoltage">--</div>
                 </div>
                 <div class="card">
-                    <div class="label">Battery SoC</div>
+                    <div class="label">SoC da Bateria</div>
                     <div class="value" id="soc">--</div>
                     <div class="sub" id="socCc">--</div>
                 </div>
                 <div class="card">
-                    <div class="label">Power</div>
+                    <div class="label">Energia</div>
                     <div class="value" id="powerKw">--</div>
                     <div class="sub" id="powerPercent">--</div>
                 </div>
                 <div class="card">
-                    <div class="label">Throttle</div>
+                    <div class="label">Acelerador</div>
                     <div class="value" id="throttlePercent">--</div>
                     <div class="sub" id="throttleRaw">--</div>
                 </div>
@@ -77,7 +77,7 @@ static const char TELEMETRY_PAGE_HTML[] PROGMEM = R"rawliteral(
                     <div class="sub" id="escCurrent">--</div>
                 </div>
                 <div class="card">
-                    <div class="label">System</div>
+                    <div class="label">Sistema</div>
                     <div class="value" id="armed">--</div>
                     <div class="sub" id="freshness">--</div>
                 </div>
@@ -236,13 +236,13 @@ const syncWakeUi = (state, reason) => {
     const button = $('wakeToggleButton');
 
     const stateMap = {
-        idle: { label: 'INACTIVE', cls: 'status-secondary', button: 'Keep Awake' },
-        requesting: { label: 'TRYING', cls: 'status-secondary', button: 'Working...' },
-        'active-native': { label: 'ACTIVE', cls: 'status-active', button: 'Disable' },
-        'active-fallback': { label: 'ACTIVE', cls: 'status-active', button: 'Disable' },
-        'needs-user-gesture': { label: 'NEED TAP', cls: 'status-warning', button: 'Keep Awake' },
-        unsupported: { label: 'UNSUPPORTED', cls: 'status-inactive', button: 'Retry' },
-        error: { label: 'RETRY', cls: 'status-warning', button: 'Retry' }
+        idle: { label: 'INATIVO', cls: 'status-secondary', button: 'Manter Ativo' },
+        requesting: { label: 'TENTANDO', cls: 'status-secondary', button: 'Processando...' },
+        'active-native': { label: 'ATIVO', cls: 'status-active', button: 'Desativar' },
+        'active-fallback': { label: 'ATIVO', cls: 'status-active', button: 'Desativar' },
+        'needs-user-gesture': { label: 'TOQUE NECESSÁRIO', cls: 'status-warning', button: 'Manter Ativo' },
+        unsupported: { label: 'NÃO SUPORTADO', cls: 'status-inactive', button: 'Tentar Novamente' },
+        error: { label: 'TENTAR NOVAMENTE', cls: 'status-warning', button: 'Tentar Novamente' }
     };
 
     const view = stateMap[state] || stateMap.idle;
@@ -259,15 +259,15 @@ const syncWakeUi = (state, reason) => {
         setText(
             'wakeHelp',
             state === 'active-native' || state === 'active-fallback'
-                ? 'Keep this page open while flying. If iPhone turns the screen off again, return here and tap the button.'
-                : 'iPhone may require a tap to keep the screen awake while this page stays open.'
+                ? 'Mantenha esta página aberta durante o voo. Se o iPhone apagar a tela novamente, volte aqui e toque no botão.'
+                : 'O iPhone pode precisar de um toque para manter a tela ativa enquanto esta página permanece aberta.'
         );
     } else {
         setText(
             'wakeHelp',
             state === 'active-native' || state === 'active-fallback'
-                ? 'Keep this page visible while flying. If the browser drops the lock, the page will try to restore it.'
-                : 'The page will try automatically first. If the screen still turns off, tap the button once.'
+                ? 'Mantenha esta página visível durante o voo. Se o navegador perder o bloqueio, a página tentará restaurá-lo.'
+                : 'A página tentará automaticamente primeiro. Se a tela ainda apagar, toque no botão uma vez.'
         );
     }
 };
@@ -293,7 +293,7 @@ const releaseWake = async (markDesired = false) => {
     }
 
     stopFallbackWake();
-    syncWakeUi('idle', 'Screen keep-awake is off.');
+    syncWakeUi('idle', 'Manter tela ativa está desligado.');
 };
 
 const attachWakeLockReleaseHandler = (sentinel) => {
@@ -301,10 +301,10 @@ const attachWakeLockReleaseHandler = (sentinel) => {
     sentinel.addEventListener('release', () => {
         wakeLockSentinel = null;
         if (wakeDesired && document.visibilityState === 'visible') {
-            syncWakeUi('needs-user-gesture', 'The browser released the wake lock. Tap the button if it does not come back.');
+            syncWakeUi('needs-user-gesture', 'O navegador liberou o bloqueio de tela. Toque no botão se não voltar.');
             scheduleWakeReacquire(300);
         } else {
-            syncWakeUi('idle', 'Screen keep-awake is off.');
+            syncWakeUi('idle', 'Manter tela ativa está desligado.');
         }
     });
 };
@@ -330,8 +330,8 @@ const tryFallbackWakeLock = async () => {
     }
     await fallbackWake.start();
     syncWakeUi('active-fallback', isAppleMobile
-        ? 'Fallback keep-awake is active for iPhone.'
-        : 'Fallback keep-awake is active.');
+        ? 'Manter ativo por fallback está ativo para iPhone.'
+        : 'Manter ativo por fallback está ativo.');
     return true;
 };
 
@@ -348,12 +348,12 @@ const tryAutoEnableWake = async () => {
     wakeDesired = true;
 
     if (document.visibilityState !== 'visible') {
-        syncWakeUi('idle', 'Open the page to enable keep-awake.');
+        syncWakeUi('idle', 'Abra a página para ativar manter ativo.');
         return false;
     }
 
     clearWakeReacquireTimer();
-    syncWakeUi('requesting', 'Trying automatic keep-awake...');
+    syncWakeUi('requesting', 'Tentando manter ativo automaticamente...');
 
     try {
         await tryNativeWakeLock();
@@ -366,15 +366,15 @@ const tryAutoEnableWake = async () => {
             syncWakeUi(
                 'needs-user-gesture',
                 isUserGestureError(error)
-                    ? 'This browser needs a tap before keep-awake can start.'
-                    : 'Automatic keep-awake is limited here. Tap the button to start the local fallback.'
+                    ? 'Este navegador precisa de um toque antes de iniciar manter ativo.'
+                    : 'Manter ativo automático é limitado aqui. Toque no botão para iniciar o fallback local.'
             );
             return false;
         }
 
         syncWakeUi(
             'unsupported',
-            'This browser does not expose a keep-awake method in the current mode.'
+            'Este navegador não expõe um método de manter ativo no modo atual.'
         );
         return false;
     }
@@ -383,7 +383,7 @@ const tryAutoEnableWake = async () => {
 const enableWakeFromUserGesture = async () => {
     wakeDesired = true;
     clearWakeReacquireTimer();
-    syncWakeUi('requesting', 'Starting keep-awake...');
+    syncWakeUi('requesting', 'Iniciando manter ativo...');
 
     try {
         await tryNativeWakeLock();
@@ -398,8 +398,8 @@ const enableWakeFromUserGesture = async () => {
             syncWakeUi(
                 'error',
                 isUserGestureError(fallbackError) || isUserGestureError(nativeError)
-                    ? 'The browser still wants a direct tap. Try the button again without leaving the page.'
-                    : 'Unable to keep the screen awake on this browser.'
+                    ? 'O navegador ainda requer um toque direto. Tente o botão novamente sem sair da página.'
+                    : 'Não é possível manter a tela ativa neste navegador.'
             );
             return false;
         }
@@ -419,7 +419,7 @@ async function reacquireWakeIfNeeded() {
 }
 
 const initTelemetryWake = () => {
-    syncWakeUi('idle', 'Preparing keep-awake controls.');
+    syncWakeUi('idle', 'Preparando controles de manter ativo.');
 
     const helpToggle = $('wakeHelpToggle');
     const helpPanel = $('wakeHelp');
@@ -458,7 +458,7 @@ const initTelemetryWake = () => {
 
         if (wakeState === 'active-fallback') {
             stopFallbackWake();
-            syncWakeUi('needs-user-gesture', 'Return to this page and tap the button if the screen starts sleeping again.');
+            syncWakeUi('needs-user-gesture', 'Volte a esta página e toque no botão se a tela começar a apagar novamente.');
         }
     });
 
@@ -482,7 +482,7 @@ const setStatus = (kind) => {
     const badge = $('statusBadge');
     if (!badge) return;
     badge.className = `status ${kind}`;
-    badge.textContent = kind === 'live' ? 'LIVE' : (kind === 'stale' ? 'STALE' : 'NO DATA');
+    badge.textContent = kind === 'live' ? 'AO VIVO' : (kind === 'stale' ? 'DESATUALIZADO' : 'SEM DADOS');
 };
 
 const renderTelemetry = (data) => {
@@ -490,25 +490,25 @@ const renderTelemetry = (data) => {
 
     if (!data.hasTelemetry) {
         setStatus('nodata');
-        setText('freshness', 'Waiting for telemetry');
+        setText('freshness', 'Aguardando telemetria');
     } else {
         const age = data.uptimeMs - data.lastTelemetryUpdateMs;
         setStatus(age > 3000 ? 'stale' : 'live');
-        setText('freshness', `Last update ${Math.max(0, age)} ms ago`);
+        setText('freshness', `Última atualização há ${Math.max(0, age)} ms`);
     }
 
     setText('batteryVoltage', fmtV(data.batteryVoltageMv || 0));
     setText('soc', `${data.batteryPercentVoltage || 0} %`);
     setText('socCc', `CC: ${data.batteryPercentCc ?? 0} %`);
     setText('powerKw', av.powerKw ? fmtKw(data.powerKwX10 ?? 0) : 'N/A');
-    setText('powerPercent', `Limit: ${data.powerPercent || 0} %`);
+    setText('powerPercent', `Limite: ${data.powerPercent || 0} %`);
     setText('throttlePercent', `${data.throttlePercent || 0} %`);
-    setText('throttleRaw', `Raw: ${data.throttleRaw || 0}`);
+    setText('throttleRaw', `Bruto: ${data.throttleRaw || 0}`);
     setText('motorTemp', fmtC(data.motorTempMc || 0));
     setText('rpm', av.rpm ? `${data.rpm ?? 0} rpm` : 'N/A');
     setText('escTemp', fmtC(data.escTempMc || 0));
     setText('escCurrent', av.current ? fmtA(data.escCurrentMa ?? 0) : 'N/A');
-    setText('armed', data.armed ? 'ARMED' : 'DISARMED');
+    setText('armed', data.armed ? 'ARMADO' : 'DESARMADO');
 
     const bmsCard = $('bmsCard');
     if (data.bms && data.bms.available) {


### PR DESCRIPTION
## Summary

- Translates all user-facing strings in the web server UI from English to Brazilian Portuguese (pt-BR)
- Technical terms intentionally kept in English: `firmware`, `rpm`, `kW`, `BLE`, `MAC`, `CSV`, `Wi-Fi`
- Each page was translated in an isolated commit for easy review and rollback

## Pages translated

- **Navigation bar** — Painel, Telemetria, Firmware, Registros, Configurações
- **Dashboard** — labels, status badges (ARMADO/DESARMADO, AO VIVO/DESATUALIZADO)
- **Configuration Hub** — section titles and descriptions
- **Power Config** — all form labels, help text, validation messages
- **Thermal Config** — all form labels, help text, validation messages
- **BMS Config** — form labels, scan status messages, BLE device labels
- **System Config** — form labels, descriptions
- **Firmware page** — titles, button, update status
- **Logs page** — table headers, action buttons, confirmation dialogs
- **Telemetry page** — data labels, wake-lock status/messages, telemetry badges
- **API responses** — all `request->send()` error and success messages returned to the browser

## Test plan

- [x] `pio run -e lolin_c3_mini_hobbywing` builds successfully (SUCCESS, no warnings)
- [ ] Manual verification on device: navigate all pages and confirm Portuguese text renders correctly
- [ ] Check that firmware update flow still shows correct success/error styling (JS check updated from `includes('Success')` to `includes('Sucesso')`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)