### PR TITLE
fix: keep motor spinning at 10% power floor during thermal limiting

### DIFF
--- a/src/Power/Power.cpp
+++ b/src/Power/Power.cpp
@@ -182,7 +182,8 @@ unsigned int Power::calcMotorTempLimit() {
     if (motorTempMilliCelsius < reductionStart) return 100;
     if (reductionStart == maxTemp) return 0;
 
-    return constrain(map(motorTempMilliCelsius, reductionStart, maxTemp, 100, 0), 0, 100);
+    return constrain(map(motorTempMilliCelsius, reductionStart, maxTemp, 100, MOTOR_TEMP_COOLING_FLOOR_PERCENT),
+                     MOTOR_TEMP_COOLING_FLOOR_PERCENT, 100);
 }
 
 unsigned int Power::calcEscTempLimit() {

--- a/src/config.h
+++ b/src/config.h
@@ -117,6 +117,8 @@ extern ADS1115 ads1115;
 // MOTOR_MAX_TEMP and MOTOR_TEMP_REDUCTION_START are now managed by Settings class
 #define MOTOR_TEMP_MIN_VALID -10000 // -10000 millicelsius = -10.000°C - Minimum valid temperature reading
 #define MOTOR_TEMP_MAX_VALID 150000 // 150000 millicelsius = 150.000°C - Maximum valid temperature reading
+// Minimum power kept when motor temp limiting is active — keeps motor spinning so forced cooling stays effective
+#define MOTOR_TEMP_COOLING_FLOOR_PERCENT 10
 
 // ========== ESC PARAMETERS ==========
 #if IS_TMOTOR


### PR DESCRIPTION
## Summary

- When motor temp protection reduces power, it previously went all the way to 0%, stopping the motor
- With forced ventilation (motor-driven cooling), stopping the motor removes the only active cooling — temperature continues rising after shutdown
- This was observed in flight logs: motor reached 102°C *after* stopping, with the pilot repeatedly trying to apply throttle while power was locked at 0%
- New behavior: power floors at `MOTOR_TEMP_COOLING_FLOOR_PERCENT` (10%) instead of 0%, keeping the motor spinning slowly for continued active cooling with negligible heat generation

## Changes

- `src/config.h`: added `MOTOR_TEMP_COOLING_FLOOR_PERCENT 10`
- `src/Power/Power.cpp`: `calcMotorTempLimit()` now floors at the cooling constant instead of 0

## Test plan

- [ ] Build all three targets (tmotor, hobbywing, xag) — no regressions
- [ ] Verify `power_percent` in telemetry never drops below 10% due to motor temp (only motor temp — battery and ESC temp limits are unaffected)
- [ ] Flight test: confirm motor keeps spinning under thermal limiting and temperature stabilizes or recovers faster than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)