### PR TITLE
feat: add timestamp to logs and sync device clock via browser

### DIFF
--- a/src/Logger/Logger.cpp
+++ b/src/Logger/Logger.cpp
@@ -1,7 +1,28 @@
 #include "Logger.h"
 #include "../Throttle/Throttle.h"
+#include <time.h>
+#include <sys/time.h>
 
 extern Throttle throttle;
+
+static const time_t MIN_VALID_EPOCH = 1577836800; // 2020-01-01 UTC
+
+bool Logger::isTimeSynced() {
+    return time(nullptr) > MIN_VALID_EPOCH;
+}
+
+void Logger::formatTimestamp(char* buf, size_t len) {
+    if (isTimeSynced()) {
+        time_t now = time(nullptr);
+        struct tm t;
+        gmtime_r(&now, &t);
+        snprintf(buf, len, "%04d-%02d-%02dT%02d:%02d:%02d",
+                 t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
+                 t.tm_hour, t.tm_min, t.tm_sec);
+    } else {
+        snprintf(buf, len, "ms:%lu", millis());
+    }
+}
 
 Logger::Logger() {
     currentFileName = "";
@@ -34,6 +55,17 @@ Logger::~Logger() {
 }
 
 void Logger::createNewFile() {
+    // Build date prefix when clock is synced (e.g. "20250419"), else empty.
+    char datePrefix[12] = "";
+    if (isTimeSynced()) {
+        time_t now = time(nullptr);
+        struct tm t;
+        gmtime_r(&now, &t);
+        snprintf(datePrefix, sizeof(datePrefix), "%04d%02d%02d",
+                 t.tm_year + 1900, t.tm_mon + 1, t.tm_mday);
+    }
+    const bool useDate = (datePrefix[0] != '\0');
+
     File root = LittleFS.open("/");
     if (!root) {
         Serial.println("Failed to open directory");
@@ -42,58 +74,67 @@ void Logger::createNewFile() {
 
     root.rewindDirectory();
 
-    int maxFileNum = 0;
-    int minEmptyFileNum = -1;
+    int maxSeqNum = 0;       // highest NNN seen for the date prefix (or overall)
+    int minEmptySeqNum = -1; // lowest NNN of an empty file for this prefix
 
     File file = root.openNextFile();
     while (file) {
         String fileName = file.name();
-        // Assuming format /00001.csv - remove leading / if present
-        if (fileName.startsWith("/")) {
-            fileName = fileName.substring(1);
+        if (fileName.startsWith("/")) fileName = fileName.substring(1);
+
+        // Accept both YYYYMMDD_NNN.csv (date) and NNNNN.csv (legacy).
+        String seqPart;
+        if (useDate) {
+            String expectedPrefix = String(datePrefix) + "_";
+            if (fileName.startsWith(expectedPrefix) && fileName.endsWith(".csv")) {
+                seqPart = fileName.substring(expectedPrefix.length(),
+                                             fileName.length() - 4);
+            }
+        } else {
+            int dotIndex = fileName.indexOf('.');
+            if (dotIndex > 0) {
+                seqPart = fileName.substring(0, dotIndex);
+            }
         }
 
-        // Check if it matches pattern digit+.<ext>
-        int dotIndex = fileName.indexOf('.');
-        if (dotIndex > 0) {
-            String numPart = fileName.substring(0, dotIndex);
-            bool isDigit = true;
-            for (unsigned int i = 0; i < numPart.length(); i++) {
-                if (!isdigit(numPart.charAt(i))) {
-                    isDigit = false;
-                    break;
-                }
+        if (seqPart.length() > 0) {
+            bool allDigits = true;
+            for (unsigned int i = 0; i < seqPart.length(); i++) {
+                if (!isdigit(seqPart.charAt(i))) { allDigits = false; break; }
             }
-            if (isDigit) {
-                int num = numPart.toInt();
-                if (num > maxFileNum) {
-                    maxFileNum = num;
-                }
-                if (file.size() == 0) {
-                    if (minEmptyFileNum < 0 || num < minEmptyFileNum) {
-                        minEmptyFileNum = num;
-                    }
+            if (allDigits) {
+                int num = seqPart.toInt();
+                if (num > maxSeqNum) maxSeqNum = num;
+                if (file.size() == 0 && (minEmptySeqNum < 0 || num < minEmptySeqNum)) {
+                    minEmptySeqNum = num;
                 }
             }
         }
         file.close();
         file = root.openNextFile();
     }
-
     root.close();
 
-    char fileNameBuf[16];
+    char fileNameBuf[32];
 
-    if (minEmptyFileNum >= 0) {
-        snprintf(fileNameBuf, sizeof(fileNameBuf), "/%05d.csv", minEmptyFileNum);
+    if (minEmptySeqNum >= 0) {
+        if (useDate) {
+            snprintf(fileNameBuf, sizeof(fileNameBuf), "/%s_%03d.csv", datePrefix, minEmptySeqNum);
+        } else {
+            snprintf(fileNameBuf, sizeof(fileNameBuf), "/%05d.csv", minEmptySeqNum);
+        }
         currentFileName = String(fileNameBuf);
         Serial.print("Reusing empty log file: ");
         Serial.println(currentFileName);
         return;
     }
 
-    int nextFileNum = maxFileNum + 1;
-    snprintf(fileNameBuf, sizeof(fileNameBuf), "/%05d.csv", nextFileNum);
+    int nextSeqNum = maxSeqNum + 1;
+    if (useDate) {
+        snprintf(fileNameBuf, sizeof(fileNameBuf), "/%s_%03d.csv", datePrefix, nextSeqNum);
+    } else {
+        snprintf(fileNameBuf, sizeof(fileNameBuf), "/%05d.csv", nextSeqNum);
+    }
     currentFileName = String(fileNameBuf);
 
     // POWER LOSS SAFETY
@@ -125,6 +166,7 @@ void Logger::openLogFile() {
     fileOpen = true;
 
     if (logFile.size() == 0 && csvHeader.length() > 0) {
+        logFile.print("timestamp,");
         logFile.print(csvHeader);
         logFile.print("\r\n");
         logFile.flush();
@@ -195,6 +237,10 @@ void Logger::log(const char* data) {
         }
     }
 
+    char tsBuf[24];
+    formatTimestamp(tsBuf, sizeof(tsBuf));
+    logFile.print(tsBuf);
+    logFile.print(",");
     logFile.print(data);
     logFile.flush(); // Force data to be written to storage immediately
 }

--- a/src/Logger/Logger.h
+++ b/src/Logger/Logger.h
@@ -17,6 +17,9 @@ public:
     void afterLogFilesClearedFromStorage();
     ~Logger();
 
+    /** Returns true if the system clock has been set (epoch > 2020). */
+    static bool isTimeSynced();
+
 private:
     String currentFileName;
     File logFile;
@@ -29,6 +32,9 @@ private:
     void openLogFile();
     void closeLogFile();
     void stopLogging();
+
+    /** Writes current time as YYYY-MM-DDTHH:MM:SS into buf, or "ms:NNNNNNN" if not synced. */
+    static void formatTimestamp(char* buf, size_t len);
 };
 
 #endif

--- a/src/WebServer/ControllerWebServer.cpp
+++ b/src/WebServer/ControllerWebServer.cpp
@@ -10,6 +10,7 @@
 #include <ArduinoJson.h>
 #include <AsyncJson.h>
 #include <esp_heap_caps.h>
+#include <sys/time.h>
 #include "Pages/CommonLayout.h"
 #include "Pages/ConfigPowerPage.h"
 #include "Pages/ConfigThermalPage.h"
@@ -214,6 +215,27 @@ void ControllerWebServer::startAP() {
         logWebHeap("/api/config/system GET");
         sendSystemConfigResponse(request);
     });
+
+    server.on("/api/settime", HTTP_POST,
+        [](AsyncWebServerRequest *request) {},
+        nullptr,
+        [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
+            if (index + len < total) return; // wait for full body
+            char buf[24] = {0};
+            size_t copyLen = len < sizeof(buf) - 1 ? len : sizeof(buf) - 1;
+            memcpy(buf, data, copyLen);
+            const int64_t epochMs = atoll(buf);
+            if (epochMs > 1577836800000LL) { // sanity: > 2020-01-01
+                struct timeval tv;
+                tv.tv_sec  = (time_t)(epochMs / 1000);
+                tv.tv_usec = (suseconds_t)((epochMs % 1000) * 1000);
+                settimeofday(&tv, nullptr);
+                request->send(200, "text/plain", "OK");
+            } else {
+                request->send(400, "text/plain", "Epoch inválido");
+            }
+        }
+    );
 
     server.on("/api/bms/scan/status", HTTP_GET, [](AsyncWebServerRequest *request) {
         logWebHeap("/api/bms/scan/status");

--- a/src/WebServer/Pages/CommonScripts.h
+++ b/src/WebServer/Pages/CommonScripts.h
@@ -36,4 +36,6 @@ const showMessage = (id, text, kind) => {
     el.className = `message ${kind}`;
     el.style.display = 'block';
 };
+
+fetch('/api/settime', { method: 'POST', body: String(Date.now()) }).catch(() => {});
 )rawliteral";


### PR DESCRIPTION
## Summary

- Every CSV log row now starts with a `timestamp` column (ISO-8601 UTC: `2025-04-19T10:30:45`, or `ms:1234567` as fallback before sync)
- Log files are named with the date when the clock is synced: `20250419_001.csv`; legacy `00001.csv` naming used as fallback
- Device clock is synced automatically — when the browser opens any portal page, `Date.now()` is silently POSTed to the new `POST /api/settime` endpoint, no user action required

## How it works

1. User opens `192.168.4.1` before or during a flight session
2. `CommonScripts.h` fires `fetch('/api/settime', { method: 'POST', body: String(Date.now()) })` on every page load
3. ESP32 calls `settimeofday()` — internal RTC is set for the remainder of the power cycle
4. Logger uses `gmtime_r()` to format UTC timestamps; if clock was never synced, falls back to `millis()`

## Test plan

- [ ] Build all three targets — no regressions ✅
- [ ] Open portal before arming: verify log file is named `YYYYMMDD_001.csv`
- [ ] Check CSV header starts with `timestamp,`
- [ ] Check rows start with `2025-...-...T...` ISO timestamp
- [ ] Arm without opening portal first: verify fallback `ms:NNNNNNN` format in rows and `00001.csv` filename
- [ ] Open portal mid-session: next log file switches to date-based naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)