### PR TITLE
feat: T-Motor Status 5 reporting via proprietary SET protocol

### DIFF
--- a/docs/tmotor-can-protocol.md
+++ b/docs/tmotor-can-protocol.md
@@ -1,8 +1,21 @@
 # T-Motor ESC — CAN Bus Protocol Analysis
 
-Reverse-engineered from three live captures on a 1 Mbps DroneCAN bus between a
-T-Motor ESC and the CloudBoxOld configurator app.  
-Capture tool: ESP32-C3 in TWAI_MODE_LISTEN_ONLY (`feature/can-monitor`).
+Two complementary sources of truth:
+
+1. **Official documentation** — `TMOTOR ESCs CAN Communication Manual V2.2.0.pdf`
+   and `t-motor-uavcan-2.2.pdf`. Defines the DRONECAN-S protocol and the
+   `Enable Reporting` Generic Instruction (msg_id 4670) — the simple way to
+   turn ESC status reports on/off.
+2. **Live captures** — three captures on a 1 Mbps DroneCAN bus between a
+   T-Motor ESC and the CloudBoxOld configurator app, taken with an ESP32-C3 in
+   `TWAI_MODE_LISTEN_ONLY` (`feature/can-monitor`). Show that CloudBoxOld does
+   **not** use the simple Enable Reporting — it uses a proprietary parameter
+   block protocol on the same DataTypeId 1000 (different internal `msg_id`).
+
+These two paths likely produce the same end result ("Status upload: Open" →
+ESC starts emitting Status 5 / DataTypeId 1154 with motor temperature). The
+official path is ~50 lines of code; the CloudBoxOld path is ~17 multi-frames
+across 3 multi-frame transfers.
 
 ---
 
@@ -63,15 +76,112 @@ All frames use 29-bit extended CAN IDs.
 
 ---
 
-## Configuration protocol (DataTypeId 1000)
+## Generic Instruction (DataTypeId 1000) — official protocol
+
+Per `TMOTOR ESCs CAN Communication Manual V2.2.0` §3.2, DataTypeId 1000 carries
+a "Generic Instruction" wrapper. The wrapper has a 6-byte header followed by a
+variable-length payload, all CRC-protected by the standard DroneCAN multi-frame
+mechanism.
+
+### `CAN_APP_PROTO_HEAD` (6 bytes)
+
+```c
+#define CAN_APP_PROTO_MAGIC 0xabcd
+
+typedef struct {
+    uint16_t magic;    // Always 0xABCD (little-endian: CD AB)
+    uint16_t msg_id;   // Internal protocol message ID
+    uint16_t len;      // Length of the payload that follows
+} CAN_APP_PROTO_HEAD;
+```
+
+### Documented internal `msg_id` values
+
+| `msg_id` | Hex     | Name                       | Payload                           |
+|---------:|---------|----------------------------|-----------------------------------|
+| 4670     | `0x123E`| `ENA_ESC_STAT_REP_MSG_ID`  | `uint32_t enable` — 0=OFF, 1=ON   |
+| 4669     | `0x123D`| `ARM_LED_CTRL_MSG_ID`      | LED control (8× ESCs)             |
+
+### Enable Reporting — the test we want to run first
+
+**`ENA_ESC_STAT_REP_T`** (4 bytes): `uint32_t enable` (0 turns reporting OFF,
+1 turns reporting ON). When ON, the ESC begins emitting Status 1–5 (DataTypeId
+1150–1154) at 10 Hz. Status 5 (1154) is the one we care about — it carries
+motor temperature.
+
+Total payload sent on DataTypeId 1000 = **6-byte header + 4-byte data = 10 bytes**.
+With 2-byte multi-frame CRC prefix = 12 bytes → 2 CAN frames.
+
+**Digital signature** (for the multi-frame CRC):
+`0x1362ab78cd12f03aULL` (Generic Instruction ID 999/1000).
+
+This is exactly what `TmotorCan::sendEnableReporting(bool enable)` already
+implements at [TmotorCan.cpp:554](../src/Tmotor/TmotorCan.cpp). It is currently
+defined but **not yet wired up** in `main.cpp`.
+
+---
+
+## Status 5 (DataTypeId 1154) — motor temperature frame
+
+Single-frame, 7 bytes data + 1 tail byte. Reported at 10 Hz once Enable
+Reporting is ON. Already parsed by `TmotorCan::handleEscStatus5()`.
+
+```c
+typedef struct {
+    int16_t idc;        // Estimated busbar current (0.1 A units)
+    int16_t cap_temp;   // Capacitor temperature (0.1 °C units)
+    int16_t motor_temp; // Motor temperature (0.1 °C units)  ← what we want
+    uint16_t resv: 8;   // Reserved
+    uint16_t tail: 8;   // DroneCAN tail byte
+} S_CAN_MSG_ESC_STAT5;
+```
+
+Signature for Status 1–5: `0x2362ab78cd12f03aULL`.
+
+---
+
+## CloudBoxOld "ESC Advanced Config" UI (observed)
+
+Screenshot of the configurator window during the capture sessions. The
+interesting toggle is **Status upload: Open / Close** — flipping it is what
+generates the SET multi-frame transfers in the captures below.
+
+| Section | Field              | Value observed       |
+|---------|--------------------|----------------------|
+| Left    | Throttle holding time | 0.25 s            |
+| Left    | Dual throttle priority| PWM First         |
+| Left    | CAN Baud Rate      | 1 M                  |
+| Left    | Over Volt (V)      | 63                   |
+| Left    | Under Volt (V)     | 20                   |
+| Left    | PWM Width Max / Min| 1940 / 1100          |
+| Right   | **Status upload**  | **Open / Close**     |
+| Right   | Status protocol    | DRONECAN-S           |
+| Right   | Status frequency   | 10 Hz                |
+| Right   | ADRW               | 6653                 |
+
+`DRONECAN-S` confirms the bus is using the DroneCAN protocol described in
+§3 of the manual (the alternative being CUBECAN, §4, which uses fixed
+`0x10000xxx` extended IDs and is not in use here).
+
+---
+
+## Configuration protocol (DataTypeId 1000) — CloudBoxOld proprietary
 
 All configuration commands originate from node `0x65` (CloudBox) as multi-frame
 DroneCAN transfers on DataTypeId 1000.  The ESC replies on DataTypeId 999.
 
+This protocol uses a **different internal `msg_id` (`0x1247`)** than the
+documented `Enable Reporting` (`0x123E`), and a different payload layout
+(parameter blocks rather than a single `uint32_t enable` flag). It is not
+covered by either PDF and was reconstructed from the captures alone.
+
 ### Magic header
 
 Every transfer payload begins with a 7-byte header.  Bytes 2–3 are always
-`CD AB` (little-endian magic `0xABCD`).  Bytes 4–5 are always `47 12`.
+`CD AB` (little-endian magic `0xABCD` — same `CAN_APP_PROTO_MAGIC` as the
+official protocol).  Bytes 4–5 are always `47 12` → internal `msg_id = 0x1247`
+(not documented in either PDF; presumably an internal "set parameter block"
+command).
 
 ```
 [0]     sequence counter (increments per command)
@@ -125,9 +235,25 @@ This identifies **parameter index `0x10` (16)** = "Status upload".
 
 ---
 
-## Implementing the toggle
+## Two paths to enable Status 5
 
-To replicate "Status upload: Open/Close" programmatically:
+### Path A — Official `Enable Reporting` (try this first)
+
+Already implemented at [TmotorCan.cpp:554](../src/Tmotor/TmotorCan.cpp). Send a
+single 2-frame transfer on DataTypeId 1000:
+
+```
+Header:  CD AB 3E 12 04 00              (magic, msg_id=0x123E, len=4)
+Data:    01 00 00 00                    (enable = 1)   or   00 00 00 00 (disable)
+CRC:     CRC16-CCITT seeded with signature 0x1362ab78cd12f03aULL
+```
+
+If after sending this we start seeing periodic Status 5 frames (DataTypeId
+1154, 8 bytes) on the bus, we're done — no need for Path B.
+
+### Path B — Replicate CloudBoxOld (fallback)
+
+To replicate "Status upload: Open/Close" the way CloudBoxOld does it:
 
 1. Send **GET** (Transfer A + Transfer B) to confirm current state from the ESC
    response on DataTypeId 999.
@@ -140,21 +266,6 @@ To replicate "Status upload: Open/Close" programmatically:
 **Important:** the sequence counter bytes [0–1] increment with each command pair.
 Replaying a fixed sequence counter may be rejected by the ESC; increment it per
 send or mirror the counter from a prior GET response.
-
----
-
-## Related ESC parameters (observed from screen captures)
-
-From the CloudBoxOld UI during the capture sessions:
-
-| Parameter | Value observed |
-|-----------|---------------|
-| Status upload | Open / Close (toggled during captures) |
-| Status protocol | DRONECAN-S |
-| Status frequency | 10 Hz |
-
-Temperature data appears in the first 2 bytes of DataTypeId 1131 frames when
-"Status upload: Open" is active.
 
 ---
 

--- a/docs/tmotor-can-protocol.md
+++ b/docs/tmotor-can-protocol.md
@@ -165,82 +165,95 @@ generates the SET multi-frame transfers in the captures below.
 
 ---
 
-## Configuration protocol (DataTypeId 1000) — CloudBoxOld proprietary
+## Configuration protocol (DataTypeId 1000) — CloudLink proprietary
 
-All configuration commands originate from node `0x65` (CloudBox) as multi-frame
-DroneCAN transfers on DataTypeId 1000.  The ESC replies on DataTypeId 999.
+All configuration commands originate from node `0x65` (CloudLink) as multi-frame
+DroneCAN transfers on DataTypeId 1000. The ESC replies on DataTypeId 999.
 
-This protocol uses a **different internal `msg_id` (`0x1247`)** than the
-documented `Enable Reporting` (`0x123E`), and a different payload layout
-(parameter blocks rather than a single `uint32_t enable` flag). It is not
-covered by either PDF and was reconstructed from the captures alone.
+The DroneCAN wrapper is the **same** `CAN_APP_PROTO_HEAD` as the official Generic
+Instruction (magic `0xABCD`, then `msg_id`, then `len`). What changes is the
+internal `msg_id` and the payload layout — none of these are documented in
+either PDF.
 
-### Magic header
+### Internal `msg_id` values seen in captures
 
-Every transfer payload begins with a 7-byte header.  Bytes 2–3 are always
-`CD AB` (little-endian magic `0xABCD` — same `CAN_APP_PROTO_MAGIC` as the
-official protocol).  Bytes 4–5 are always `47 12` → internal `msg_id = 0x1247`
-(not documented in either PDF; presumably an internal "set parameter block"
-command).
+| `msg_id` | Hex      | Direction | Purpose                           |
+|---------:|----------|-----------|-----------------------------------|
+| 4667     | `0x123B` | 0x65 → ESC| Periodic poll (4-byte payload)    |
+| 4668     | `0x123C` | ESC → 0x65| Response to 0x123B (8 bytes)      |
+| 4675     | `0x1243` | 0x65 → ESC| Read register/parameter request   |
+| 4676     | `0x1244` | ESC → 0x65| Response to 0x1243                |
+| 4679     | `0x1247` | both      | **Parameter block read/write**    |
+| 4683     | `0x124B` | 0x65 → ESC| Periodic poll (4-byte payload)    |
+| 4684     | `0x124C` | ESC → 0x65| Response to 0x124B (12 bytes)     |
 
+The earlier doc claim that "every transfer uses `msg_id = 0x1247`" was wrong —
+that's only the SET/GET parameter command. The 9-frame periodic bursts
+CloudLink sends every ~200 ms are `0x123B` + `0x124B` polls.
+
+### SET command (clicking "Set" with "Status upload" toggled)
+
+Three back-to-back multi-frame transfers, all on DataTypeId 1000 with
+internal `msg_id = 0x1247`:
+
+| Transfer | `len` | Frames | Inner data starts with     | What it carries |
+|---------:|:-----:|:------:|----------------------------|-----------------|
+| 1        | 0x0C  | 3      | `41 00 01 00 02 00 ...`    | Section 0x02 — likely "begin write" handshake |
+| 2        | 0x38  | 10     | `41 00 01 00 04 00 ...`    | Section 0x04 — general ESC config (PWM range, voltage limits, etc.) |
+| 3        | 0x2C  | 8      | `41 00 01 00 10 00 ...`    | Section 0x10 — **Status upload setting** |
+
+All three transfers begin with the inner-data prefix `41 00 01 00 SS 00`
+where `SS` is the section index. Status upload is section `0x10` (16).
+
+**Captured Transfer 1 inner data (12 bytes, identical Close vs Open):**
 ```
-[0]     sequence counter (increments per command)
-[1]     sequence counter high byte
-[2-3]   CD AB  (magic 0xABCD)
-[4-5]   47 12  (protocol marker)
-[6]     payload length byte (0x0C = GET, 0x38 = SET large block, 0x2C = SET param block)
+41 00 01 00 02 00 04 00 00 00 00 00
 ```
 
-### GET command
-
-Sent as **two back-to-back transfers** on DataTypeId 1000:
-
-**Transfer A** (3 frames, header length 0x0C):
+**Captured Transfer 2 inner data (56 bytes, identical Close vs Open):**
 ```
-E4 31 CD AB 47 12 0C | 00 41 00 01 00 0E 00 | 04 00 00 00 00 00 <tail>
+41 00 01 00 04 00 30 00 01 00 01 00 4C 04 00 00
+94 07 00 00 76 02 C8 00 01 00 00 00 00 00 A0 0F
+A0 0F 32 00 01 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00
 ```
+Notable: `94 07` = 0x0794 = 1940 (PWM Width Max from the CloudLink screenshot);
+`4C 04` = 0x044C = 1100 (PWM Width Min). So this block carries the user's
+generic ESC settings — replicating it verbatim will overwrite custom config.
 
-**Transfer B** (3 frames, header length 0x0C):
+**Captured Transfer 3 inner data (44 bytes, ONLY byte 28 differs):**
 ```
-53 20 CD AB 47 12 0C | 00 41 00 01 00 02 00 | 04 00 00 00 00 00 <tail>
+41 00 01 00 10 00 00 24 00 7B 00 00 00 02 00 00
+00 00 00 00 00 40 42 0F 00 00 00 00 XX 00 01 00
+00 00 00 00 00 00 00 00 00 FA 00 00 00
 ```
+- `XX = 0x00` → Status upload **Close** (ESC stops emitting Status 1–5)
+- `XX = 0x80` → Status upload **Open** (ESC emits Status 1–5 at 10 Hz)
 
-The ESC responds on DataTypeId 999 with the current parameter block.
+Byte 28 of the inner data = byte 1 of CAN frame 6 of Transfer 3 (the second
+non-CRC byte of that frame). The earlier doc said "byte 36 / first byte of
+F6" — that was wrong on both counts.
 
-### SET command
+### Notes on protocol behaviour
 
-Sent as **three back-to-back transfers** on DataTypeId 1000:
-
-**Transfer 1** — identical to GET Transfer B above.
-
-**Transfer 2** — large block (header length 0x38, ~8 frames):  
-Contains general ESC parameters.  Content is identical whether enabling or
-disabling "Status upload" — this block carries other settings.
-
-**Transfer 3** — parameter block (header length 0x2C, ~7 frames):  
-Contains the "Status upload" (temperature reporting) setting.
-
-Frame 2 of Transfer 3 always contains:
-```
-00 41 00 01 00 10 00
-```
-This identifies **parameter index `0x10` (16)** = "Status upload".
-
-**Byte 36 of the assembled Transfer 3 payload** (first byte of the 6th CAN frame):
-
-| Value  | Meaning |
-|--------|---------|
-| `0x00` | Status upload: **Close** — ESC stops reporting temperature |
-| `0x80` | Status upload: **Open** — ESC reports temperature at configured frequency |
+- **Persistence**: the Status upload setting is saved in the ESC's non-volatile
+  memory. Power cycling does not reset it. Once CloudLink writes "Close",
+  the ESC stays in Close until something writes "Open" again.
+- **Path A vs Path B**: the official `Enable Reporting` (msg_id `0x123E`) only
+  enables reporting at the *session* level. It works when the ESC's persistent
+  Status upload is `Open`, but it cannot override a persistent `Close` —
+  empirically verified by us. To reliably enable Status 5 from the firmware
+  regardless of the ESC's saved state, Path B (this proprietary SET) is needed.
+- **Source node**: captures show `0x65` (CloudLink) but the ESC does not appear
+  to filter by source — sending from any node ID works.
 
 ---
 
 ## Two paths to enable Status 5
 
-### Path A — Official `Enable Reporting` (try this first)
+### Path A — Official `Enable Reporting` (msg_id 0x123E)
 
-Already implemented at [TmotorCan.cpp:554](../src/Tmotor/TmotorCan.cpp). Send a
-single 2-frame transfer on DataTypeId 1000:
+Single 2-frame transfer on DataTypeId 1000:
 
 ```
 Header:  CD AB 3E 12 04 00              (magic, msg_id=0x123E, len=4)
@@ -248,24 +261,25 @@ Data:    01 00 00 00                    (enable = 1)   or   00 00 00 00 (disable
 CRC:     CRC16-CCITT seeded with signature 0x1362ab78cd12f03aULL
 ```
 
-If after sending this we start seeing periodic Status 5 frames (DataTypeId
-1154, 8 bytes) on the bus, we're done — no need for Path B.
+**Test result:** `enable=1` works — Status 5 (1154) starts arriving at 10 Hz.
+**`enable=0` is ignored** by the ESC. Worse, this command only takes effect
+at the *session* level: if CloudLink has saved "Status upload: Close" in the
+ESC's non-volatile memory, Path A cannot override it. Verified empirically.
 
-### Path B — Replicate CloudBoxOld (fallback)
+### Path B — Replicate CloudLink's parameter SET (msg_id 0x1247)
 
-To replicate "Status upload: Open/Close" the way CloudBoxOld does it:
+Sends three multi-frame transfers verbatim from the captured CloudLink traffic:
+Transfer 1, Transfer 2, Transfer 3. Transfer 3 has byte 28 of its inner data
+patched to `0x80` (Open) or `0x00` (Close).
 
-1. Send **GET** (Transfer A + Transfer B) to confirm current state from the ESC
-   response on DataTypeId 999.
-2. Build **Transfer 3** from a captured reference payload and patch byte 36:
-   - `0x00` → disable temperature reporting
-   - `0x80` → enable temperature reporting
-3. Send **Transfer 1 → Transfer 2 → Transfer 3** in sequence on DataTypeId 1000
-   from source node `0x65` (or whichever node ID we assign to the controller).
+This writes the Status upload setting persistently in the ESC's non-volatile
+memory, so it survives reboots and overrides any earlier CloudLink state.
 
-**Important:** the sequence counter bytes [0–1] increment with each command pair.
-Replaying a fixed sequence counter may be rejected by the ESC; increment it per
-send or mirror the counter from a prior GET response.
+**Caveat:** Transfer 2 carries general ESC config (PWM range, voltage limits)
+and is replayed verbatim from the capture. If the user changes those settings
+via CloudLink later, replaying our hardcoded Transfer 2 will revert them.
+The user should configure the ESC fully in CloudLink first, then leave it
+alone — our firmware only flips the Status upload bit.
 
 ---
 

--- a/docs/tmotor-can-protocol.md
+++ b/docs/tmotor-can-protocol.md
@@ -1,0 +1,166 @@
+# T-Motor ESC — CAN Bus Protocol Analysis
+
+Reverse-engineered from three live captures on a 1 Mbps DroneCAN bus between a
+T-Motor ESC and the CloudBoxOld configurator app.  
+Capture tool: ESP32-C3 in TWAI_MODE_LISTEN_ONLY (`feature/can-monitor`).
+
+---
+
+## Nodes observed on the bus
+
+| Node ID | Role | Evidence |
+|---------|------|----------|
+| `0x01`  | T-Motor ESC | Emits NodeStatus (DataTypeId 341) periodically |
+| `0x65`  | CloudBox configurator | Sends all DataTypeId 1000 commands |
+| `0x02`, `0x42`, `0x45` | Other devices | Periodic status frames only |
+
+---
+
+## DataTypeId map
+
+| DataTypeId | Direction | Description |
+|-----------|-----------|-------------|
+| 341  | ESC → bus      | NodeStatus heartbeat (standard DroneCAN) |
+| 999  | ESC → 0x65     | ESC response to GET/SET commands (multi-frame, ~3 frames) |
+| 1000 | 0x65 → ESC     | CloudBox command to ESC (GET: 2 frames; SET: 8+ frames) |
+| 1001 | ESC → bus      | High-frequency ESC telemetry ~10 Hz (multi-frame) |
+| 1131 | ESC → bus      | High-frequency ESC telemetry ~10 Hz — first 2 bytes contain motor temperature |
+
+---
+
+## Frame structure (DroneCAN recap)
+
+All frames use 29-bit extended CAN IDs.
+
+**Message frame** (bit 7 of CAN ID = 0):
+
+```
+[28:26] Priority (3 bits)
+[25:8]  DataTypeId (18 bits, effective range 0–32767)
+[7]     0 (message)
+[6:0]   Source Node ID
+```
+
+**Service frame** (bit 7 of CAN ID = 1):
+
+```
+[28:26] Priority
+[25:16] Service Type ID
+[15]    1 = Request / 0 = Response
+[14:8]  Destination Node ID
+[7]     1 (service)
+[6:0]   Source Node ID
+```
+
+**Tail byte** (last byte of every CAN frame payload):
+
+```
+[7]    Start-of-Frame
+[6]    End-of-Frame
+[5]    Toggle
+[4:0]  Transfer ID
+```
+
+---
+
+## Configuration protocol (DataTypeId 1000)
+
+All configuration commands originate from node `0x65` (CloudBox) as multi-frame
+DroneCAN transfers on DataTypeId 1000.  The ESC replies on DataTypeId 999.
+
+### Magic header
+
+Every transfer payload begins with a 7-byte header.  Bytes 2–3 are always
+`CD AB` (little-endian magic `0xABCD`).  Bytes 4–5 are always `47 12`.
+
+```
+[0]     sequence counter (increments per command)
+[1]     sequence counter high byte
+[2-3]   CD AB  (magic 0xABCD)
+[4-5]   47 12  (protocol marker)
+[6]     payload length byte (0x0C = GET, 0x38 = SET large block, 0x2C = SET param block)
+```
+
+### GET command
+
+Sent as **two back-to-back transfers** on DataTypeId 1000:
+
+**Transfer A** (3 frames, header length 0x0C):
+```
+E4 31 CD AB 47 12 0C | 00 41 00 01 00 0E 00 | 04 00 00 00 00 00 <tail>
+```
+
+**Transfer B** (3 frames, header length 0x0C):
+```
+53 20 CD AB 47 12 0C | 00 41 00 01 00 02 00 | 04 00 00 00 00 00 <tail>
+```
+
+The ESC responds on DataTypeId 999 with the current parameter block.
+
+### SET command
+
+Sent as **three back-to-back transfers** on DataTypeId 1000:
+
+**Transfer 1** — identical to GET Transfer B above.
+
+**Transfer 2** — large block (header length 0x38, ~8 frames):  
+Contains general ESC parameters.  Content is identical whether enabling or
+disabling "Status upload" — this block carries other settings.
+
+**Transfer 3** — parameter block (header length 0x2C, ~7 frames):  
+Contains the "Status upload" (temperature reporting) setting.
+
+Frame 2 of Transfer 3 always contains:
+```
+00 41 00 01 00 10 00
+```
+This identifies **parameter index `0x10` (16)** = "Status upload".
+
+**Byte 36 of the assembled Transfer 3 payload** (first byte of the 6th CAN frame):
+
+| Value  | Meaning |
+|--------|---------|
+| `0x00` | Status upload: **Close** — ESC stops reporting temperature |
+| `0x80` | Status upload: **Open** — ESC reports temperature at configured frequency |
+
+---
+
+## Implementing the toggle
+
+To replicate "Status upload: Open/Close" programmatically:
+
+1. Send **GET** (Transfer A + Transfer B) to confirm current state from the ESC
+   response on DataTypeId 999.
+2. Build **Transfer 3** from a captured reference payload and patch byte 36:
+   - `0x00` → disable temperature reporting
+   - `0x80` → enable temperature reporting
+3. Send **Transfer 1 → Transfer 2 → Transfer 3** in sequence on DataTypeId 1000
+   from source node `0x65` (or whichever node ID we assign to the controller).
+
+**Important:** the sequence counter bytes [0–1] increment with each command pair.
+Replaying a fixed sequence counter may be rejected by the ESC; increment it per
+send or mirror the counter from a prior GET response.
+
+---
+
+## Related ESC parameters (observed from screen captures)
+
+From the CloudBoxOld UI during the capture sessions:
+
+| Parameter | Value observed |
+|-----------|---------------|
+| Status upload | Open / Close (toggled during captures) |
+| Status protocol | DRONECAN-S |
+| Status frequency | 10 Hz |
+
+Temperature data appears in the first 2 bytes of DataTypeId 1131 frames when
+"Status upload: Open" is active.
+
+---
+
+## Capture environment
+
+- **Bus speed:** 1 Mbps
+- **Sniffer:** ESP32-C3 (TWAI_MODE_LISTEN_ONLY), GPIO2=TX, GPIO3=RX
+- **Firmware:** `feature/can-monitor` branch
+- **Captures:** `can.log`, `can2.log`, `can3.log` (local, not committed)

--- a/src/Tmotor/TmotorCan.cpp
+++ b/src/Tmotor/TmotorCan.cpp
@@ -65,6 +65,8 @@ TmotorCan::TmotorCan() {
     lastMotorTempFromCanMs = 0;
     lastPushSci = 0;
     lastThrottleSend = 0;
+    escDetectedAtMs = 0;
+    enableReportingSent = false;
     transferId = 0;
 
     escTemperature = 0;
@@ -122,20 +124,30 @@ void TmotorCan::parseEscMessage(twai_message_t *canMsg) {
 }
 
 void TmotorCan::handle() {
-    // Check if ESC is detected and Enable Reporting not sent yet
     extern Canbus canbus;
     if (canbus.getEscNodeId() == 0) {
         return;
     }
 
-    // CAN throttle period: 2.5ms (400 Hz)
-    // Check if 2ms has elapsed (allowing for some jitter)
+    // Track when ESC was first detected so we can delay before enabling reporting
+    if (escDetectedAtMs == 0) {
+        escDetectedAtMs = millis();
+    }
+
+    // Send Enable Reporting once, 2 s after ESC detection, so the bus is stable.
+    // Tested result: enable=1 works (Status 5 arrives at 10 Hz); enable=0 is ignored
+    // by the ESC firmware — reporting only stops on power cycle.
+    if (!enableReportingSent && millis() - escDetectedAtMs >= 2000) {
+        sendEnableReporting(true);
+        enableReportingSent = true;
+    }
+
+    // CAN throttle period: 2.5ms (400 Hz); allow some jitter
     if (millis() - lastThrottleSend < 2) {
         return;
     }
 
     setRawThrottle(0);
-
     lastThrottleSend = millis();
 }
 
@@ -360,13 +372,10 @@ void TmotorCan::handleEscStatus5(twai_message_t *canMsg) {
     int16_t idc = parseInt16LE(canMsg->data, STATUS5_IDC_OFFSET);
     int16_t cap_temp_raw = parseInt16LE(canMsg->data, STATUS5_CAP_TEMP_OFFSET);
     int16_t motor_temp_raw = parseInt16LE(canMsg->data, STATUS5_MOTOR_TEMP_OFFSET);
-    (void)idc; // only used in DEBUG_PRINT — suppress unused-variable in release builds
+    (void)idc;  // only used in DEBUG_PRINT
 
-    // Convert from 0.1°C units to Celsius using integer division with rounding
-    // For positive values: (value + 5) / 10 rounds correctly
-    // For negative values: (value - 5) / 10 rounds correctly
     int16_t cap_temp_celsius = (cap_temp_raw >= 0) ? (cap_temp_raw + 5) / 10 : (cap_temp_raw - 5) / 10;
-    (void)cap_temp_celsius; // only used in DEBUG_PRINT — suppress unused-variable in release builds
+    (void)cap_temp_celsius;  // only used in DEBUG_PRINT
     int16_t motor_temp_celsius = (motor_temp_raw >= 0) ? (motor_temp_raw + 5) / 10 : (motor_temp_raw - 5) / 10;
 
     // Store (convert to uint8_t, with range check)
@@ -378,16 +387,15 @@ void TmotorCan::handleEscStatus5(twai_message_t *canMsg) {
         this->motorTemperature = (uint8_t)motor_temp_celsius;
     }
 
-    DEBUG_PRINT("[Tmotor] Status 5: IDC=");
-    // Format current with 1 decimal: idc is in 0.1A units
+    DEBUG_PRINT("[Tmotor] Status5(1154): IDC=");
     DEBUG_PRINT(idc / 10);
     DEBUG_PRINT(".");
     DEBUG_PRINT(abs(idc % 10));
-    DEBUG_PRINT("A, Cap=");
+    DEBUG_PRINT("A Cap=");
     DEBUG_PRINT(cap_temp_celsius);
-    DEBUG_PRINT("°C, Motor=");
+    DEBUG_PRINT("C Motor=");
     DEBUG_PRINT(motor_temp_celsius);
-    DEBUG_PRINTLN("°C");
+    DEBUG_PRINTLN("C");
 
     lastMotorTempFromCanMs = millis();
     lastReadPushCan = millis();

--- a/src/Tmotor/TmotorCan.cpp
+++ b/src/Tmotor/TmotorCan.cpp
@@ -552,6 +552,10 @@ void TmotorCan::sendParamCfg(uint8_t escNodeId, uint16_t feedbackRate, bool save
 }
 
 void TmotorCan::sendEnableReporting(bool enable) {
+    Serial.print("[Tmotor] sendEnableReporting(");
+    Serial.print(enable ? "true" : "false");
+    Serial.println(") — DroneCAN Generic Instruction msg_id=0x123E");
+
     // Payload: Header (6 bytes) + Data (4 bytes) = 10 bytes
     uint8_t payload[10];
 

--- a/src/Tmotor/TmotorCan.cpp
+++ b/src/Tmotor/TmotorCan.cpp
@@ -129,16 +129,21 @@ void TmotorCan::handle() {
         return;
     }
 
-    // Track when ESC was first detected so we can delay before enabling reporting
+    // Track when ESC was first detected so we can delay the first SET attempt
     if (escDetectedAtMs == 0) {
         escDetectedAtMs = millis();
     }
 
-    // Send Enable Reporting once, 2 s after ESC detection, so the bus is stable.
-    // Tested result: enable=1 works (Status 5 arrives at 10 Hz); enable=0 is ignored
-    // by the ESC firmware — reporting only stops on power cycle.
+    // Path B: replicate CloudLink's proprietary parameter SET to enable Status
+    // upload (Status 1–5 reporting) persistently. Path A (Enable Reporting,
+    // msg_id 0x123E) was tested and cannot override CloudLink's saved "Close"
+    // — only the proprietary command on msg_id 0x1247 sticks.
+    //
+    // Sent once, 2 s after ESC detection. The setting persists in the ESC's
+    // non-volatile memory, so this only needs to run once per ESC; we send it
+    // every boot in case the user clicked "Close" via CloudLink in between.
     if (!enableReportingSent && millis() - escDetectedAtMs >= 2000) {
-        sendEnableReporting(true);
+        sendStatusUploadSet(true);
         enableReportingSent = true;
     }
 
@@ -559,92 +564,147 @@ void TmotorCan::sendParamCfg(uint8_t escNodeId, uint16_t feedbackRate, bool save
     DEBUG_PRINTLN();
 }
 
-void TmotorCan::sendEnableReporting(bool enable) {
-    Serial.print("[Tmotor] sendEnableReporting(");
-    Serial.print(enable ? "true" : "false");
-    Serial.println(") — DroneCAN Generic Instruction msg_id=0x123E");
+void TmotorCan::sendGenericInstructionMultiframe(uint16_t internalMsgId,
+                                                  const uint8_t* innerData,
+                                                  size_t innerLen) {
+    // Build the wrapped Generic Instruction payload:
+    //   [0..1] magic (CD AB)
+    //   [2..3] internal msg_id (little-endian)
+    //   [4..5] inner length (little-endian)
+    //   [6..]  inner data
+    const size_t HEADER_LEN = 6;
+    const size_t MAX_INNER = 64;
+    if (innerLen > MAX_INNER) return;
 
-    // Payload: Header (6 bytes) + Data (4 bytes) = 10 bytes
-    uint8_t payload[10];
+    uint8_t wrapped[HEADER_LEN + MAX_INNER];
+    wrapped[0] = 0xCD;
+    wrapped[1] = 0xAB;
+    wrapped[2] = (uint8_t)(internalMsgId & 0xFF);
+    wrapped[3] = (uint8_t)((internalMsgId >> 8) & 0xFF);
+    wrapped[4] = (uint8_t)(innerLen & 0xFF);
+    wrapped[5] = (uint8_t)((innerLen >> 8) & 0xFF);
+    memcpy(wrapped + HEADER_LEN, innerData, innerLen);
+    const size_t totalLen = HEADER_LEN + innerLen;
 
-    // CAN_APP_PROTO_HEAD
-    payload[0] = 0xCD;  // magic[0] (0xABCD little-endian)
-    payload[1] = 0xAB;  // magic[1]
-    payload[2] = 0x3E;  // msg_id[0] (4670 = 0x123E)
-    payload[3] = 0x12;  // msg_id[1]
-    payload[4] = 0x04;  // len[0] (4 bytes)
-    payload[5] = 0x00;  // len[1]
-
-    // ENA_ESC_STAT_REP_T
-    uint32_t enable_val = enable ? 1 : 0;
-    payload[6] = (uint8_t)(enable_val & 0xFF);
-    payload[7] = (uint8_t)((enable_val >> 8) & 0xFF);
-    payload[8] = (uint8_t)((enable_val >> 16) & 0xFF);
-    payload[9] = (uint8_t)((enable_val >> 24) & 0xFF);
-
-    // Calculate CRC
-    uint64_t signature = 0x1362ab78cd12f03aULL;  // Generic instruction signature
+    // Multi-frame DroneCAN CRC seeded with the Generic Instruction signature.
     uint16_t crc = 0xFFFF;
-    crc = crcAddSignature(crc, signature);
-    crc = crcAdd(crc, payload, 10);
+    crc = crcAddSignature(crc, 0x1362ab78cd12f03aULL);
+    crc = crcAdd(crc, wrapped, totalLen);
 
-    // CAN ID para Generic Instruction (1000)
+    // DroneCAN message-frame CAN ID for DataTypeId 1000.
     uint32_t priority = 0x18;  // LOW
-    uint32_t dataTypeId = genericInstructionDataTypeId;  // 1000
-    uint32_t service = 0;
+    uint32_t dataTypeId = genericInstructionDataTypeId;
     uint32_t srcNodeId = canbus.getNodeId();
+    uint32_t canId = (priority << 24) | (dataTypeId << 8) | (srcNodeId & 0x7F);
 
-    uint32_t canId = (priority << 24) |
-                     (dataTypeId << 8) |
-                     (service << 7) |
-                     (srcNodeId & 0x7F);
+    twai_message_t msg;
+    msg.identifier = canId;
+    msg.extd = 1;
+    msg.rtr = 0;
+    msg.ss = 0;
+    msg.self = 0;
+    msg.dlc_non_comp = 0;
 
-    twai_message_t localCanMsg;
-    localCanMsg.identifier = canId;
-    localCanMsg.extd = 1;
-    localCanMsg.rtr = 0;
-    localCanMsg.ss = 0;
-    localCanMsg.self = 0;
-    localCanMsg.dlc_non_comp = 0;
+    const uint8_t tid = transferId & TRANSFER_ID_MASK;
 
-    uint8_t currentTransferId = transferId;
-
-    // Frame 1: CRC (2) + payload[0-4] (5) = 7 bytes
-    localCanMsg.data[0] = (uint8_t)(crc & 0xFF);
-    localCanMsg.data[1] = (uint8_t)((crc >> 8) & 0xFF);
-    localCanMsg.data[2] = payload[0];  // magic[0]
-    localCanMsg.data[3] = payload[1];  // magic[1]
-    localCanMsg.data[4] = payload[2];  // msg_id[0]
-    localCanMsg.data[5] = payload[3];  // msg_id[1]
-    localCanMsg.data[6] = payload[4];  // len[0]
-    localCanMsg.data[7] = 0x80 | (currentTransferId & 0x1F);  // SOF=1, EOF=0, Toggle=0
-    localCanMsg.data_length_code = 8;
-
-    esp_err_t tx_result = twai_transmit(&localCanMsg, pdMS_TO_TICKS(100));
-    if (tx_result != ESP_OK) {
-        DEBUG_PRINTLN("[ERROR] Frame 1 TX failed");
+    // First frame: CRC (2) + up to 5 bytes of wrapped + tail.
+    size_t pos = 0;
+    bool fitsInOne = (totalLen <= 5);
+    {
+        size_t chunk = totalLen < 5 ? totalLen : 5;
+        msg.data[0] = (uint8_t)(crc & 0xFF);
+        msg.data[1] = (uint8_t)((crc >> 8) & 0xFF);
+        for (size_t i = 0; i < chunk; i++) msg.data[2 + i] = wrapped[i];
+        uint8_t tail = (uint8_t)((1U << 7) | tid);   // SOF=1
+        if (fitsInOne) tail |= (uint8_t)(1U << 6);   // also EOF
+        msg.data[2 + chunk] = tail;
+        msg.data_length_code = (uint8_t)(2 + chunk + 1);
+        if (twai_transmit(&msg, pdMS_TO_TICKS(100)) != ESP_OK) return;
+        pos = chunk;
+    }
+    if (fitsInOne) {
+        transferId = (transferId + 1) & TRANSFER_ID_MASK;
         return;
     }
-    delay(2);
 
-    // Frame 2: payload[5-9] (5 bytes) - LAST FRAME
-    localCanMsg.data[0] = payload[5];  // len[1]
-    localCanMsg.data[1] = payload[6];  // enable[0]
-    localCanMsg.data[2] = payload[7];  // enable[1]
-    localCanMsg.data[3] = payload[8];  // enable[2]
-    localCanMsg.data[4] = payload[9];  // enable[3]
-    localCanMsg.data[5] = 0x00;  // padding
-    localCanMsg.data[6] = 0x00;  // padding
-    localCanMsg.data[7] = 0x40 | (currentTransferId & 0x1F);  // SOF=0, EOF=1, Toggle=0
-    localCanMsg.data_length_code = 8;
-
-    tx_result = twai_transmit(&localCanMsg, pdMS_TO_TICKS(100));
-    if (tx_result != ESP_OK) {
-        DEBUG_PRINTLN("[ERROR] Frame 2 TX failed");
-        return;
+    // Subsequent frames: up to 7 bytes payload + tail. Toggle bit alternates
+    // starting at 1 for frame 2 (matches captured CloudLink pattern).
+    bool toggle = true;
+    while (pos < totalLen) {
+        delay(1);
+        size_t remaining = totalLen - pos;
+        size_t chunk = remaining > 7 ? 7 : remaining;
+        bool isLast = (chunk == remaining);
+        for (size_t i = 0; i < chunk; i++) msg.data[i] = wrapped[pos + i];
+        uint8_t tail = tid;
+        if (isLast) tail |= (uint8_t)(1U << 6);
+        if (toggle) tail |= (uint8_t)(1U << 5);
+        msg.data[chunk] = tail;
+        msg.data_length_code = (uint8_t)(chunk + 1);
+        if (twai_transmit(&msg, pdMS_TO_TICKS(100)) != ESP_OK) return;
+        pos += chunk;
+        toggle = !toggle;
     }
 
     transferId = (transferId + 1) & TRANSFER_ID_MASK;
+}
+
+void TmotorCan::sendEnableReporting(bool enable) {
+    Serial.print("[Tmotor] sendEnableReporting(");
+    Serial.print(enable ? "true" : "false");
+    Serial.println(") — Path A: Generic Instruction msg_id=0x123E");
+
+    // ENA_ESC_STAT_REP_T (4 bytes): uint32_t enable. 0=OFF, 1=ON.
+    uint32_t enableVal = enable ? 1U : 0U;
+    uint8_t inner[4] = {
+        (uint8_t)(enableVal & 0xFF),
+        (uint8_t)((enableVal >> 8) & 0xFF),
+        (uint8_t)((enableVal >> 16) & 0xFF),
+        (uint8_t)((enableVal >> 24) & 0xFF),
+    };
+    sendGenericInstructionMultiframe(0x123E, inner, sizeof(inner));
+}
+
+void TmotorCan::sendStatusUploadSet(bool open) {
+    Serial.print("[Tmotor] sendStatusUploadSet(");
+    Serial.print(open ? "open" : "close");
+    Serial.println(") — Path B: proprietary msg_id=0x1247, 3 transfers");
+
+    // Captured verbatim from CloudLink. See docs/tmotor-can-protocol.md.
+    // Transfer 1 (section 0x02 — begin write handshake; 12 bytes inner data).
+    static const uint8_t T1_INNER[12] = {
+        0x41, 0x00, 0x01, 0x00, 0x02, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+    };
+    // Transfer 2 (section 0x04 — general ESC config: PWM range, voltage limits.
+    // Replicating verbatim will overwrite any custom CloudLink config in this
+    // section; users should set their config in CloudLink before relying on
+    // this firmware path. 56 bytes inner data).
+    static const uint8_t T2_INNER[56] = {
+        0x41, 0x00, 0x01, 0x00, 0x04, 0x00, 0x30, 0x00,
+        0x01, 0x00, 0x01, 0x00, 0x4C, 0x04, 0x00, 0x00,
+        0x94, 0x07, 0x00, 0x00, 0x76, 0x02, 0xC8, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xA0, 0x0F,
+        0xA0, 0x0F, 0x32, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    };
+    // Transfer 3 (section 0x10 — Status upload toggle; 44 bytes inner data,
+    // byte 28 toggles between 0x00 (Close) and 0x80 (Open)).
+    uint8_t t3_inner[44] = {
+        0x41, 0x00, 0x01, 0x00, 0x10, 0x00, 0x24, 0x00,
+        0x7B, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x40, 0x42, 0x0F, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xFA, 0x00, 0x00, 0x00,
+    };
+    t3_inner[28] = open ? 0x80 : 0x00;
+
+    sendGenericInstructionMultiframe(0x1247, T1_INNER, sizeof(T1_INNER));
+    delay(10);
+    sendGenericInstructionMultiframe(0x1247, T2_INNER, sizeof(T2_INNER));
+    delay(10);
+    sendGenericInstructionMultiframe(0x1247, t3_inner, sizeof(t3_inner));
 }
 
 // Float16 conversion functions (based on PDF section 5.2)

--- a/src/Tmotor/TmotorCan.cpp
+++ b/src/Tmotor/TmotorCan.cpp
@@ -100,25 +100,12 @@ void TmotorCan::parseEscMessage(twai_message_t *canMsg) {
     }
 
     if (dataTypeId == escStatus5DataTypeId) {  // 1154
-        DEBUG_PRINTLN("[Tmotor] -> Processing ESC_STATUS 5");
         handleEscStatus5(canMsg);
         return;
     }
 
     if (dataTypeId == pushCanDataTypeId) {
-        DEBUG_PRINT("[PUSHCAN] Frame received - DLC=");
-        DEBUG_PRINT(canMsg->data_length_code);
-        DEBUG_PRINT(" Data=[");
-        for (uint8_t i = 0; i < canMsg->data_length_code && i < 8; i++) {
-            if (i > 0) { DEBUG_PRINT(" "); }
-            if (canMsg->data[i] < 0x10) { DEBUG_PRINT("0"); }
-            DEBUG_PRINT_HEX(canMsg->data[i], HEX);
-        }
-        DEBUG_PRINTLN("]");
         handlePushCan(canMsg);
-        DEBUG_PRINT("[PUSHCAN] T_Motor=");
-        DEBUG_PRINT(motorTemperature);
-        DEBUG_PRINTLN("°C");
         return;
     }
 }

--- a/src/Tmotor/TmotorCan.h
+++ b/src/Tmotor/TmotorCan.h
@@ -46,7 +46,8 @@ public:
     // Initialization and configuration methods
     void requestParam(uint16_t paramIndex);  // Request parameter value
     void sendParamCfg(uint8_t escNodeId, uint16_t feedbackRate = 50, bool savePermanent = true);  // Send ParamCfg to configure ESC telemetry rate
-    void sendEnableReporting(bool enable);  // Send Enable Reporting command (Message ID 1000) to enable/disable ESC status reporting
+    void sendEnableReporting(bool enable);  // Path A — Generic Instruction msg_id 0x123E. Session-only enable; cannot override CloudLink's persistent "Close".
+    void sendStatusUploadSet(bool open);    // Path B — replicate CloudLink's 3-transfer SET on msg_id 0x1247. Persists across reboots.
 
     // Getters for ESC data
     uint16_t getRpm() { return rpm; }
@@ -83,7 +84,7 @@ private:
     unsigned long lastThrottleSend;
     unsigned long escDetectedAtMs;        // millis() when ESC was first detected on bus
 
-    bool enableReportingSent;  // true once sendEnableReporting(true) has been sent
+    bool enableReportingSent;  // true once sendStatusUploadSet(true) has been sent for the current ESC session
 
     // Transfer control
     uint8_t transferId;
@@ -151,6 +152,14 @@ private:
     void handleEscStatus(twai_message_t *canMsg);
     void handleEscStatus5(twai_message_t *canMsg);  // Handle Status 5 (Message ID 1154) for motor temperature
     void handlePushCan(twai_message_t *canMsg);
+
+    // Sends a Generic Instruction (DataTypeId 1000) wrapped payload as a
+    // multi-frame DroneCAN transfer. Computes CRC, splits into 7-byte chunks,
+    // emits SOF/EOF/Toggle bits in the tail byte. Used by both Path A
+    // (sendEnableReporting) and Path B (sendStatusUploadSet).
+    void sendGenericInstructionMultiframe(uint16_t internalMsgId,
+                                          const uint8_t* innerData,
+                                          size_t innerLen);
 
     // Float16 conversion methods
     float convertFloat16ToFloat(uint16_t value);

--- a/src/Tmotor/TmotorCan.h
+++ b/src/Tmotor/TmotorCan.h
@@ -81,6 +81,9 @@ private:
     unsigned long lastMotorTempFromCanMs;  // Status 5 or PUSHCAN motor temp payload
     unsigned long lastPushSci;
     unsigned long lastThrottleSend;
+    unsigned long escDetectedAtMs;        // millis() when ESC was first detected on bus
+
+    bool enableReportingSent;  // true once sendEnableReporting(true) has been sent
 
     // Transfer control
     uint8_t transferId;

--- a/src/WebServer/ControllerWebServer.cpp
+++ b/src/WebServer/ControllerWebServer.cpp
@@ -23,6 +23,9 @@
 #include "Pages/LegacyIndexPage.h"
 #include "../Version.h"
 #include "../Logger/Logger.h"
+#if IS_TMOTOR
+#include "../Tmotor/TmotorCan.h"
+#endif
 #include <vector>
 
 extern Logger logger;
@@ -488,6 +491,31 @@ void ControllerWebServer::startAP() {
     savePinHandler->setMethod(HTTP_POST);
     savePinHandler->setMaxContentLength(128);
     server.addHandler(savePinHandler);
+
+#if IS_TMOTOR
+    // T-Motor test endpoints — turn ESC Status 1–5 reporting on/off via the
+    // documented Generic Instruction (msg_id 0x123E). Bypasses the CloudBoxOld
+    // proprietary parameter block protocol. See docs/tmotor-can-protocol.md.
+    server.on("/api/tmotor/reporting/enable", HTTP_POST, [](AsyncWebServerRequest *request) {
+        if (!checkPin(request)) { request->send(403, "text/plain", "PIN inválido"); return; }
+        if (canbus.getEscNodeId() == 0) {
+            request->send(503, "application/json", "{\"ok\":false,\"error\":\"ESC not detected on bus\"}");
+            return;
+        }
+        tmotorCan.sendEnableReporting(true);
+        request->send(200, "application/json", "{\"ok\":true,\"enabled\":true}");
+    });
+
+    server.on("/api/tmotor/reporting/disable", HTTP_POST, [](AsyncWebServerRequest *request) {
+        if (!checkPin(request)) { request->send(403, "text/plain", "PIN inválido"); return; }
+        if (canbus.getEscNodeId() == 0) {
+            request->send(503, "application/json", "{\"ok\":false,\"error\":\"ESC not detected on bus\"}");
+            return;
+        }
+        tmotorCan.sendEnableReporting(false);
+        request->send(200, "application/json", "{\"ok\":true,\"enabled\":false}");
+    });
+#endif
 
     // Telemetry API
     server.on("/api/telemetry", HTTP_GET, [](AsyncWebServerRequest *request){

--- a/src/WebServer/ControllerWebServer.cpp
+++ b/src/WebServer/ControllerWebServer.cpp
@@ -493,16 +493,17 @@ void ControllerWebServer::startAP() {
     server.addHandler(savePinHandler);
 
 #if IS_TMOTOR
-    // T-Motor test endpoints — turn ESC Status 1–5 reporting on/off via the
-    // documented Generic Instruction (msg_id 0x123E). Bypasses the CloudBoxOld
-    // proprietary parameter block protocol. See docs/tmotor-can-protocol.md.
+    // T-Motor Status upload control — Path B (proprietary msg_id 0x1247).
+    // Replicates CloudLink's parameter SET, which writes the "Status upload"
+    // toggle persistently in the ESC's non-volatile memory. See
+    // docs/tmotor-can-protocol.md.
     server.on("/api/tmotor/reporting/enable", HTTP_POST, [](AsyncWebServerRequest *request) {
         if (!checkPin(request)) { request->send(403, "text/plain", "PIN inválido"); return; }
         if (canbus.getEscNodeId() == 0) {
             request->send(503, "application/json", "{\"ok\":false,\"error\":\"ESC not detected on bus\"}");
             return;
         }
-        tmotorCan.sendEnableReporting(true);
+        tmotorCan.sendStatusUploadSet(true);
         request->send(200, "application/json", "{\"ok\":true,\"enabled\":true}");
     });
 
@@ -512,7 +513,7 @@ void ControllerWebServer::startAP() {
             request->send(503, "application/json", "{\"ok\":false,\"error\":\"ESC not detected on bus\"}");
             return;
         }
-        tmotorCan.sendEnableReporting(false);
+        tmotorCan.sendStatusUploadSet(false);
         request->send(200, "application/json", "{\"ok\":true,\"enabled\":false}");
     });
 #endif


### PR DESCRIPTION
## Summary

- **Reverse-engineered T-Motor CAN protocol** for enabling Status 5 (DataTypeId 1154) reporting, which carries motor temperature (int16, 0.1 °C), busbar current, and capacitor temperature at 10 Hz
- **Path A investigated first** — official DroneCAN Generic Instruction (msg_id 0x123E) enables Status 5 in-session but cannot override the ESC's persistent "Status upload: Close" state written by CloudLink to non-volatile memory
- **Path B implemented** — replicates CloudLink's proprietary parameter SET (msg_id 0x1247) with three multi-frame transfers, writing the toggle to NVM so it survives reboots; Transfer 3 byte 28 is patched (0x80 = Open, 0x00 = Close)
- **Auto-enable on ESC detection** — `TmotorCan::handle()` calls Path B once after a 2 s stabilisation delay when the ESC first appears on the CAN bus; no manual intervention needed
- **HTTP endpoints** added for manual control: `POST /api/tmotor/reporting/enable` and `/disable` (PIN-protected, ESC-presence checked)
- **Protocol documented** in `docs/tmotor-can-protocol.md`: DataTypeId map, Generic Instruction wrapper, GET/SET command structure, two-path explanation, and known caveats (Transfer 2 carries hardcoded ESC config from capture)
- **Debug log cleanup** — removed per-frame PUSHCAN hex dump and Status 5 routing noise from debug builds

## Test plan

- [ ] Flash `lolin_c3_mini_tmotor` and confirm Status 5 frames appear in serial log within ~2 s of ESC power-on
- [ ] Power-cycle ESC and confirm reporting persists (Path B written to NVM)
- [ ] Test `POST /api/tmotor/reporting/disable` and `enable` endpoints from web portal
- [ ] Verify motor temperature reads correctly in Xctod BLE telemetry and web dashboard
- [ ] Build `lolin_c3_mini_hobbywing` and `lolin_c3_mini_xag` — confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)