### PR TITLE
fix: reduce heap pressure on tmotor build (BMS lazy init + PROGMEM dashboard + streamed /list)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .pio
-.vscode/.browse.c_cpp.db*
-.vscode/c_cpp_properties.json
-.vscode/launch.json
-.vscode/ipch
+.vscode/
 .DS_Store
 .worktrees
 docs/superpowers/
+docs/*.html
+docs/ANALISE-COMPARATIVA-EPPG.md
+architecture_review*.md
+recommended_fixes*.md

--- a/controller/.gitignore
+++ b/controller/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/controller/src/BluetoothBms/BluetoothBms.cpp
+++ b/controller/src/BluetoothBms/BluetoothBms.cpp
@@ -17,9 +17,6 @@ constexpr uint32_t WEB_SCAN_DURATION_SECONDS = 5;
 } // namespace
 
 void BluetoothBms::init() {
-    jbdBms.init();
-    dalyBms.init();
-    jkBms.init();
     clearWebScanResults();
 }
 
@@ -31,6 +28,16 @@ void BluetoothBms::update() {
     const uint8_t activeType = getActiveType();
     const String mac = settings.getBmsMac();
 
+    // Lazy-init the selected backend exactly once (init() is idempotent).
+    if (activeType == BmsTypeJbd) {
+        jbdBms.init();
+    } else if (activeType == BmsTypeDaly) {
+        dalyBms.init();
+    } else if (activeType == BmsTypeJk) {
+        jkBms.init();
+    }
+
+    // setEnabled() and update() are no-ops on uninitialized backends.
     jbdBms.setMacAddress(mac);
     jbdBms.setEnabled(activeType == BmsTypeJbd);
 

--- a/controller/src/DalyBms/DalyBms.cpp
+++ b/controller/src/DalyBms/DalyBms.cpp
@@ -30,7 +30,7 @@ DalyBms::DalyBms()
     : pClient_(nullptr), pCharRx_(nullptr), pCharTx_(nullptr),
       connectQueue_(nullptr), connectTaskHandle_(nullptr), stateMutex_(nullptr),
       connectSessionId_(0),
-      state_(Idle), enabled_(false), connected_(false), hasData_(false), hasCellData_(false),
+      state_(Idle), initialized_(false), enabled_(false), connected_(false), hasData_(false), hasCellData_(false),
       lastConnectAttempt_(0), lastRequestMillis_(0), rxLen_(0),
       packVoltageMilliVolts_(0), packCurrentMilliAmps_(0), socPercent_(0),
       remainingCapacityMilliAh_(0), cycleCount_(0), cellCount_(0), tempCount_(0),
@@ -41,6 +41,7 @@ DalyBms::DalyBms()
 }
 
 void DalyBms::init() {
+    if (initialized_) return;
     s_dalyBms = this;
     stateMutex_ = xSemaphoreCreateMutex();
     connectQueue_ = xQueueCreate(1, sizeof(uint8_t));
@@ -48,16 +49,17 @@ void DalyBms::init() {
         DEBUG_PRINTLN("[Daly] ERROR: mutex or connect queue create failed");
         return;
     }
-    // pClient_ is created lazily in connectTask to avoid allocating BLE heap
-    // for inactive backends (all three BMS types are init'd at boot).
     if (xTaskCreate(connectTask, "daly_conn", 4096, this, 1, &connectTaskHandle_) != pdPASS) {
         DEBUG_PRINTLN("[Daly] ERROR: connect task create failed");
+        return;
     }
     state_ = Idle;
+    initialized_ = true;
     DEBUG_PRINTLN("[Daly] Init OK");
 }
 
 void DalyBms::setEnabled(bool enabled) {
+    if (!initialized_) return;
     enabled_ = enabled;
     if (!enabled_) {
         resetConnection();

--- a/controller/src/DalyBms/DalyBms.cpp
+++ b/controller/src/DalyBms/DalyBms.cpp
@@ -72,6 +72,7 @@ void DalyBms::setMacAddress(const String& macAddress) {
 }
 
 void DalyBms::update() {
+    if (!initialized_) return;
     switch (state_) {
         case Idle:
             if (!enabled_ || macAddress_.length() < 17 || throttle.isArmed()) {

--- a/controller/src/DalyBms/DalyBms.h
+++ b/controller/src/DalyBms/DalyBms.h
@@ -70,6 +70,7 @@ private:
     SemaphoreHandle_t stateMutex_;
     uint32_t connectSessionId_;
     State state_;
+    bool initialized_;
     bool enabled_;
     bool connected_;
     bool hasData_;

--- a/controller/src/JbdBms/JbdBms.cpp
+++ b/controller/src/JbdBms/JbdBms.cpp
@@ -32,7 +32,7 @@ JbdBms::JbdBms()
       txQueue_(nullptr), txTaskHandle_(nullptr),
       connectQueue_(nullptr), connectTaskHandle_(nullptr), stateMutex_(nullptr),
       connectSessionId_(0),
-      state_(Idle), enabled_(false), connected_(false), hasData_(false),
+      state_(Idle), initialized_(false), enabled_(false), connected_(false), hasData_(false),
       lastConnectAttempt_(0), lastRequestMillis_(0), rxLen_(0),
       packVoltageMilliVolts_(0), packCurrentMilliAmps_(0), socPercent_(0),
       cellCount_(0), ntcCount_(0), cycleCount_(0),
@@ -49,6 +49,7 @@ JbdBms::JbdBms()
 // init
 // ---------------------------------------------------------------------------
 void JbdBms::init() {
+    if (initialized_) return;
     s_jbdBms = this;
     stateMutex_ = xSemaphoreCreateMutex();
     connectQueue_ = xQueueCreate(1, sizeof(uint8_t));
@@ -56,19 +57,19 @@ void JbdBms::init() {
         DEBUG_PRINTLN("[JBD] ERROR: mutex or connect queue create failed");
         return;
     }
-    // BLEDevice::init() must have been called by the main system.
-    // pClient_ is created lazily in connectTask to avoid allocating BLE heap
-    // for inactive backends (all three BMS types are init'd at boot).
     txQueue_ = xQueueCreate(4, sizeof(BleFrame));
     xTaskCreate(txTask, "jbd_tx", 2048, this, 1, &txTaskHandle_);
     if (xTaskCreate(connectTask, "jbd_conn", 4096, this, 1, &connectTaskHandle_) != pdPASS) {
         DEBUG_PRINTLN("[JBD] ERROR: connect task create failed");
+        return;
     }
     state_ = Idle;
+    initialized_ = true;
     DEBUG_PRINTLN("[JBD] Init OK");
 }
 
 void JbdBms::setEnabled(bool enabled) {
+    if (!initialized_) return;
     enabled_ = enabled;
     if (!enabled_) {
         resetConnection();

--- a/controller/src/JbdBms/JbdBms.cpp
+++ b/controller/src/JbdBms/JbdBms.cpp
@@ -57,12 +57,12 @@ void JbdBms::init() {
         DEBUG_PRINTLN("[JBD] ERROR: mutex or connect queue create failed");
         return;
     }
-    txQueue_ = xQueueCreate(4, sizeof(BleFrame));
-    xTaskCreate(txTask, "jbd_tx", 2048, this, 1, &txTaskHandle_);
     if (xTaskCreate(connectTask, "jbd_conn", 4096, this, 1, &connectTaskHandle_) != pdPASS) {
         DEBUG_PRINTLN("[JBD] ERROR: connect task create failed");
         return;
     }
+    txQueue_ = xQueueCreate(4, sizeof(BleFrame));
+    xTaskCreate(txTask, "jbd_tx", 2048, this, 1, &txTaskHandle_);
     state_ = Idle;
     initialized_ = true;
     DEBUG_PRINTLN("[JBD] Init OK");
@@ -278,6 +278,7 @@ void JbdBms::txTask(void* arg) {
 // update — state machine, call from loop()
 // ---------------------------------------------------------------------------
 void JbdBms::update() {
+    if (!initialized_) return;
     switch (state_) {
 
         // ------------------------------------------------------------------

--- a/controller/src/JbdBms/JbdBms.h
+++ b/controller/src/JbdBms/JbdBms.h
@@ -87,6 +87,7 @@ private:
     SemaphoreHandle_t stateMutex_;
     uint32_t      connectSessionId_; // incremented on resetConnection() to drop stale connect results
     State        state_;
+    bool         initialized_;
     bool         enabled_;
     bool         connected_;
     bool         hasData_;

--- a/controller/src/JkBms/JkBms.cpp
+++ b/controller/src/JkBms/JkBms.cpp
@@ -32,7 +32,7 @@ JkBms::JkBms()
       txQueue_(nullptr), txTaskHandle_(nullptr),
       connectQueue_(nullptr), connectTaskHandle_(nullptr), stateMutex_(nullptr),
       connectSessionId_(0),
-      state_(Idle), enabled_(false), connected_(false),
+      state_(Idle), initialized_(false), enabled_(false), connected_(false),
       lastConnectAttempt_(0), lastRequestMillis_(0), lastCellDataMillis_(0),
       deviceInfoRequested_(false), hasCellData_(false),
       rxLen_(0), protocol_(JkProtocol_32S)
@@ -46,6 +46,7 @@ JkBms::JkBms()
 // init
 // ---------------------------------------------------------------------------
 void JkBms::init() {
+    if (initialized_) return;
     s_jkBms = this;
     stateMutex_ = xSemaphoreCreateMutex();
     connectQueue_ = xQueueCreate(1, sizeof(uint8_t));
@@ -53,18 +54,19 @@ void JkBms::init() {
         DEBUG_PRINTLN("[JK] ERROR: mutex or connect queue create failed");
         return;
     }
-    // pClient_ is created lazily in connectTask to avoid allocating BLE heap
-    // for inactive backends (all three BMS types are init'd at boot).
     txQueue_ = xQueueCreate(4, sizeof(BleFrame));
     xTaskCreate(txTask, "jk_tx", 2048, this, 1, &txTaskHandle_);
     if (xTaskCreate(connectTask, "jk_conn", 4096, this, 1, &connectTaskHandle_) != pdPASS) {
         DEBUG_PRINTLN("[JK] ERROR: connect task create failed");
+        return;
     }
     state_ = Idle;
+    initialized_ = true;
     DEBUG_PRINTLN("[JK] Init OK");
 }
 
 void JkBms::setEnabled(bool enabled) {
+    if (!initialized_) return;
     enabled_ = enabled;
     if (!enabled_) {
         resetConnection();

--- a/controller/src/JkBms/JkBms.cpp
+++ b/controller/src/JkBms/JkBms.cpp
@@ -54,12 +54,12 @@ void JkBms::init() {
         DEBUG_PRINTLN("[JK] ERROR: mutex or connect queue create failed");
         return;
     }
-    txQueue_ = xQueueCreate(4, sizeof(BleFrame));
-    xTaskCreate(txTask, "jk_tx", 2048, this, 1, &txTaskHandle_);
     if (xTaskCreate(connectTask, "jk_conn", 4096, this, 1, &connectTaskHandle_) != pdPASS) {
         DEBUG_PRINTLN("[JK] ERROR: connect task create failed");
         return;
     }
+    txQueue_ = xQueueCreate(4, sizeof(BleFrame));
+    xTaskCreate(txTask, "jk_tx", 2048, this, 1, &txTaskHandle_);
     state_ = Idle;
     initialized_ = true;
     DEBUG_PRINTLN("[JK] Init OK");
@@ -273,6 +273,7 @@ void JkBms::txTask(void* arg) {
 // update — state machine, call from loop()
 // ---------------------------------------------------------------------------
 void JkBms::update() {
+    if (!initialized_) return;
     switch (state_) {
 
         case Idle: {

--- a/controller/src/JkBms/JkBms.h
+++ b/controller/src/JkBms/JkBms.h
@@ -64,6 +64,7 @@ private:
     SemaphoreHandle_t stateMutex_;
     uint32_t          connectSessionId_;
     State             state_;
+    bool              initialized_;
     bool              enabled_;
     bool              connected_;
     String            macAddress_;

--- a/controller/src/WebServer/ControllerWebServer.cpp
+++ b/controller/src/WebServer/ControllerWebServer.cpp
@@ -922,27 +922,32 @@ void ControllerWebServer::startAP() {
 
     // List files API
     server.on("/list", HTTP_GET, [](AsyncWebServerRequest *request){
-        String json = "[";
-        File root = LittleFS.open("/");
-        if(root){
-            File file = root.openNextFile();
-            bool first = true;
-            while(file){
-                String fileName = String(file.name());
-                // Ensure leading slash for consistency
-                if(!fileName.startsWith("/")) fileName = "/" + fileName;
+        AsyncResponseStream* resp = request->beginResponseStream("application/json");
+        if (!resp) { request->send(500, "text/plain", "Sem memória"); return; }
 
-                // Only list log files
-                if(fileName.endsWith(".csv") || fileName.endsWith(".txt")) {
-                    if(!first) json += ",";
+        resp->print('[');
+        File root = LittleFS.open("/");
+        bool first = true;
+        if (root) {
+            File file = root.openNextFile();
+            char entry[80];
+            while (file) {
+                const char* name = file.name();
+                size_t nameLen = strlen(name);
+                bool isCsv = nameLen > 4 && strcmp(name + nameLen - 4, ".csv") == 0;
+                bool isTxt = nameLen > 4 && strcmp(name + nameLen - 4, ".txt") == 0;
+                if (isCsv || isTxt) {
+                    if (!first) resp->print(',');
                     first = false;
-                    json += "{\"name\":\"" + fileName + "\",\"size\":" + String(file.size()) + "}";
+                    snprintf(entry, sizeof(entry), "{\"name\":\"/%s\",\"size\":%u}",
+                             name, (unsigned)file.size());
+                    resp->print(entry);
                 }
                 file = root.openNextFile();
             }
         }
-        json += "]";
-        request->send(200, "application/json", json);
+        resp->print(']');
+        request->send(resp);
     });
 
     // Delete file API

--- a/controller/src/WebServer/ControllerWebServer.cpp
+++ b/controller/src/WebServer/ControllerWebServer.cpp
@@ -245,11 +245,20 @@ void ControllerWebServer::startAP() {
 
     dnsServer.start(53, "*", apIP);
 
-    // Handle root URL
+    // Handle root URL — served as PROGMEM chunks to avoid ~25 KB heap spike
     server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
-        String page = renderDashboardPage();
-        applyCommonTokens(page, APP_VERSION, __DATE__, __TIME__, CONTROLLER_LABEL);
-        request->send(200, "text/html", page);
+        AsyncResponseStream* resp = request->beginResponseStream("text/html; charset=utf-8");
+        if (!resp) { request->send(500, "text/plain", "Sem memória"); return; }
+        resp->print(FPSTR(DASHBOARD_HTML_P1));
+        resp->print(APP_VERSION);
+        resp->print(FPSTR(DASHBOARD_HTML_P2));
+        resp->print(__DATE__);
+        resp->print(FPSTR(DASHBOARD_HTML_P3));
+        resp->print(__TIME__);
+        resp->print(FPSTR(DASHBOARD_HTML_P4));
+        resp->print(CONTROLLER_LABEL);
+        resp->print(FPSTR(DASHBOARD_HTML_P5));
+        request->send(resp);
     });
 
     server.on("/api/config/power", HTTP_GET, [](AsyncWebServerRequest *request){
@@ -802,6 +811,17 @@ void ControllerWebServer::startAP() {
     server.on("/config.css", HTTP_GET, [](AsyncWebServerRequest *request){
         logWebHeap("/config.css");
         request->send(200, "text/css; charset=utf-8", reinterpret_cast<const uint8_t*>(COMMON_CSS), strlen(COMMON_CSS));
+    });
+
+    server.on("/config-common.js", HTTP_GET, [](AsyncWebServerRequest *request){
+        logWebHeap("/config-common.js");
+        request->send(200, "application/javascript; charset=utf-8",
+            reinterpret_cast<const uint8_t*>(COMMON_JS), strlen(COMMON_JS));
+    });
+
+    server.on("/dashboard.js", HTTP_GET, [](AsyncWebServerRequest *request){
+        logWebHeap("/dashboard.js");
+        request->send_P(200, "application/javascript; charset=utf-8", DASHBOARD_JS);
     });
 
     server.on("/config-power.js", HTTP_GET, [](AsyncWebServerRequest *request){

--- a/controller/src/WebServer/Pages/CommonLayout.h
+++ b/controller/src/WebServer/Pages/CommonLayout.h
@@ -79,18 +79,3 @@ inline String renderPage(const PageSpec& spec) {
     page += "</body></html>";
     return page;
 }
-
-inline void applyCommonTokens(String& page, const char* appVersion, const char* buildDate, const char* buildTime, const char* controllerLabel) {
-    if (appVersion) {
-        page.replace("%APP_VERSION%", appVersion);
-    }
-    if (buildDate) {
-        page.replace("%BUILD_DATE%", buildDate);
-    }
-    if (buildTime) {
-        page.replace("%BUILD_TIME%", buildTime);
-    }
-    if (controllerLabel) {
-        page.replace("%CONTROLLER%", controllerLabel);
-    }
-}

--- a/controller/src/WebServer/Pages/DashboardPage.h
+++ b/controller/src/WebServer/Pages/DashboardPage.h
@@ -1,27 +1,43 @@
 #pragma once
 
-#include "CommonLayout.h"
+// Dashboard served as PROGMEM chunks streamed via AsyncResponseStream.
+// Tokens (APP_VERSION, BUILD_DATE, BUILD_TIME, CONTROLLER_LABEL) are
+// printed inline between static chunks — no heap String concatenation.
+//
+// Split points:
+//   P1 → up to APP_VERSION insertion
+//   P2 → between APP_VERSION and BUILD_DATE
+//   P3 → space between BUILD_DATE and BUILD_TIME
+//   P4 → between BUILD_TIME and CONTROLLER_LABEL
+//   P5 → from after CONTROLLER_LABEL to end of </html>
 
-inline String renderDashboardPage() {
-    const char* body = R"rawliteral(
+static const char DASHBOARD_HTML_P1[] PROGMEM = R"rawliteral(<!DOCTYPE html><html><head><title>FlyController Painel</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="/config.css"><script src="/config-common.js" defer></script><script src="/dashboard.js" defer></script></head><body><div class="page"><div class="topbar"><a class="nav-btn active" href="/">Painel</a><a class="nav-btn" href="/telemetry">Telemetria</a><a class="nav-btn" href="/firmware">Firmware</a><a class="nav-btn" href="/logs-page">Registros</a><a class="nav-btn" href="/config">Configura&#xE7;&#xF5;es</a></div>
 <div class="panel">
     <h1>FlyController Painel</h1>
-    <div class="sub">Acesso rápido e status básico do dispositivo</div>
+    <div class="sub">Acesso r&#xE1;pido e status b&#xE1;sico do dispositivo</div>
 </div>
 
 <div class="grid">
     <div class="card">
-        <div class="label">Versão do Firmware</div>
-        <div class="value">%APP_VERSION%</div>
-        <div class="sub">Build: %BUILD_DATE% %BUILD_TIME%</div>
+        <div class="label">Vers&#xE3;o do Firmware</div>
+        <div class="value">)rawliteral";
+
+static const char DASHBOARD_HTML_P2[] PROGMEM = R"rawliteral(</div>
+        <div class="sub">Build: )rawliteral";
+
+static const char DASHBOARD_HTML_P3[] PROGMEM = " ";
+
+static const char DASHBOARD_HTML_P4[] PROGMEM = R"rawliteral(</div>
     </div>
     <div class="card">
         <div class="label">Tipo de Controlador</div>
-        <div class="value">%CONTROLLER%</div>
+        <div class="value">)rawliteral";
+
+static const char DASHBOARD_HTML_P5[] PROGMEM = R"rawliteral(</div>
         <div class="sub">Tempo ligado: <span id="uptime">--</span></div>
     </div>
     <div class="card">
-        <div class="label">Tensão da Bateria</div>
+        <div class="label">Tens&#xE3;o da Bateria</div>
         <div class="value" id="batteryVoltage">--</div>
         <div class="sub">Telemetria: <span id="freshness">--</span></div>
     </div>
@@ -36,9 +52,9 @@ inline String renderDashboardPage() {
         <div class="sub">Motor acumulado</div>
     </div>
 </div>
-)rawliteral";
+</div></body></html>)rawliteral";
 
-    const char* script = R"rawliteral(
+static const char DASHBOARD_JS[] PROGMEM = R"rawliteral(
 const formatVoltage = (mv) => `${(mv / 1000).toFixed(2)} V`;
 const fmtSeconds = s => {
     const h = Math.floor(s / 3600);
@@ -64,24 +80,10 @@ function loadDashboard() {
             setText('freshness', `${age} ms`);
         })
         .catch(() => {
-            setText('telemetryState', 'Indisponível');
+            setText('telemetryState', 'Indispon\xEDvel');
         });
 }
 
 loadDashboard();
 setInterval(loadDashboard, 1000);
 )rawliteral";
-
-    PageSpec spec = {
-        "FlyController Painel",
-        "/",
-        body,
-        nullptr,
-        script,
-        nullptr,
-        nullptr,
-        nullptr
-    };
-
-    return renderPage(spec);
-}

--- a/throttle/.gitignore
+++ b/throttle/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch


### PR DESCRIPTION
## Summary

- **BMS lazy init**: `BluetoothBms::init()` no longer initializes all three BMS backends at boot. The active backend is initialized lazily on the first `update()` call. Saves ~12 KB of permanent FreeRTOS task-stack heap (only the configured backend's tasks are created).
- **Dashboard PROGMEM**: The `/` route no longer builds a ~25 KB `String` in heap on every page load. Static HTML is stored in flash (`PROGMEM`) and streamed via `AsyncResponseStream`.
- **Streamed `/list`**: The `/list` endpoint no longer concatenates a `String` per log file. Uses `AsyncResponseStream` + a fixed 80-byte stack buffer per entry.

Together these eliminate ~40–50 KB of heap pressure that was causing the tmotor build (which starts with less free heap than XAG due to the TWAI driver) to crash when the web server was accessed.

## Technical details

- Each BMS backend (`DalyBms`, `JbdBms`, `JkBms`) gains an `initialized_` flag. `init()` is idempotent (safe to call every loop). `setEnabled()` and `update()` guard on `initialized_` so uninitialized backends are no-ops.
- `JbdBms` and `JkBms` fix a latent partial-init bug: `txQueue_`/`txTask` are now created only after `connectTask` succeeds, preventing an orphaned tx task on failed init.
- Dashboard HTML is split into PROGMEM chunks (P1–P5) around the runtime values (`APP_VERSION`, `__DATE__`, `__TIME__`, `CONTROLLER_LABEL`). JS assets served as `/config-common.js` and `/dashboard.js`.

## Hardware validation (tmotor build, JBD BMS configured)

Tested on hardware with tag `2026-06-17.1` (baseline) vs this branch, same device and conditions (ESC connected, BLE BMS active, web server loaded).

| Metric | `2026-06-17.1` (baseline) | This branch |
|---|---|---|
| Min heap reached | 29,352 bytes | 32,140 bytes |
| Largest free block (after page load) | **14,836 bytes** | 21,492 bytes |
| Crash after BLE connect | ✅ always | ❌ does not occur |

**Root cause of the crash:** with the baseline firmware, loading the telemetry page fragments the heap down to a 14.8 KB largest free block. When the BLE stack then tries to allocate a `BLEClient`, the allocation fails and returns `nullptr`. The code accesses the pointer without a null check → Load access fault (`MCAUSE=0x05`, `MTVAL=0x00000000`) → panic/reboot. The optimized firmware keeps 6+ KB more of contiguous free heap, the allocation succeeds, and the device runs stably through ESC operation, BMS polling, and continued web server access.

## Test Plan

- [x] Build all three targets: `lolin_c3_mini_tmotor`, `lolin_c3_mini_xag`, `lolin_c3_mini_hobbywing` — all pass
- [x] On hardware (tmotor + JBD BMS): device runs stably through web server access, BLE connection, ESC operation, and CSV logging — no crashes
- [x] Heap floor confirmed at 32,140 bytes (vs 29,352 baseline) with motor running
- [ ] Confirm only the configured BMS backend init line appears in serial log on boot