### PR TITLE
fix: reduce throttle-to-motor latency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,8 @@ while (canbus.receive(&msg)) {
 - **Battery voltage:** Progressive reduction below nominal (configurable via Settings)
 - **Motor temp:** Linear reduction 50°C → 60°C
 - **ESC temp:** Linear reduction 80°C → 110°C
-- **Throttle ramp:** `THROTTLE_RAMP_UP_US_PER_MS` (accel) / `THROTTLE_RAMP_DOWN_US_PER_MS` (decel)
-- **XAG wake-up:** 1.5 s at 5% PWM before ramp when starting from stopped (`XAG_MOTOR_REACTION_DELAY_MS`)
+- **Throttle engage gate:** motor output stays at `ESC_MIN_PWM` until the filtered throttle clears `throttlePinMin + 2%` of the calibrated range, and releases back below `throttlePinMin + 1%` (hysteresis) — see `ThrottleEngagementLogic`. There is no acceleration ramp; PWM tracks the mapped throttle position directly.
+- **XAG wake-up:** 1.5 s at 5% PWM before jumping directly to target when starting from stopped (`XAG_MOTOR_REACTION_DELAY_MS`)
 
 ## Settings (Persistent)
 

--- a/controller/src/CLAUDE.md
+++ b/controller/src/CLAUDE.md
@@ -91,7 +91,7 @@ Use `#if IS_HOBBYWING`, `#if IS_TMOTOR`, `#if IS_XAG`, `#if USES_CAN_BUS` — no
 I2C 16-bit ADC (Adafruit ADS1X15). All analog readings go through `ads1115.readChannel(N)`. Channels: 0=Throttle, 1=MotorTemp, 2=EscTemp (XAG), 3=Battery voltage (XAG/Tmotor). Initialized first in `setup()`.
 
 ### Throttle — `Throttle/`
-Hall sensor input. Accepts `ReadFn`. Handles arming state machine, calibration (3-second sweep), and oversampling (30 samples, 4 readings each). `throttle.isArmed()` gates ESC output.
+Hall sensor input. Accepts `ReadFn`. Handles arming state machine, calibration (3-second sweep), and an 8-sample moving average. `throttle.isArmed()` gates ESC output. A separate engage/release hysteresis gate (`ThrottleEngagementLogic`, host-tested in `test/ThrottleEngagementLogicTest.cpp`) protects against Hall-sensor drift/noise at idle — `throttle.isEngaged()` must be true (filtered reading > `throttlePinMin + 2%` of range, released below `+1%`) before `Power` will output anything above `ESC_MIN_PWM`.
 
 ### Temperature — `Temperature/`
 NTC thermistor via Steinhart-Hart (beta=3600, R0=10kΩ). Accepts `ReadFn` + `adcVoltageRef`. Multiple instances: `motorTemp` (all builds), `escTemp` (XAG only).
@@ -107,7 +107,7 @@ Empirical tuning for the current 3.3 V hardware with BC337 transistor stage and 
 `getBeepEvents()` returns a ring buffer of up to 8 `BeepEvent` snapshots (oldest first), each with fields `{seq, freq, onMs, offMs, reps, active}`, populated by `startBeep()` and cleared by `stop()`. The web server reads this to include a `buzzer` array in `/api/telemetry`. On the first successful poll the telemetry page primes `bzLastSeq` to the highest seq without playing anything (prevents stale replays); subsequent polls play all events with `seq > bzLastSeq` in order using an audio-time cursor so back-to-back one-shots don't overlap.
 
 ### Power — `Power/`
-Computes ESC PWM from throttle position, applying battery voltage limiting, motor temp limiting, ESC temp limiting, and ramp rate control. `getPwm()` is called every loop to get the current pulse width for `esc.writeMicroseconds()`.
+Computes ESC PWM from throttle position, applying battery voltage limiting, motor temp limiting, and ESC temp limiting. `getPwm()` is called every loop to get the current pulse width for `esc.writeMicroseconds()`; output is gated to `ESC_MIN_PWM` unless `throttle.isEngaged()` (see Throttle). No acceleration ramp — PWM tracks the mapped throttle position directly, except on XAG builds where `useSmoothStart` still applies the 1.5 s wake-up delay before jumping to target.
 `getActiveLimitCauses()` returns a bitmask (`PowerLimitCause`) of which limiters are currently active. Battery cause is only set when `telemetry.hasData()` (excludes the conservative 50% startup floor). Enum values: `POWER_LIMIT_BATTERY`, `POWER_LIMIT_MOTOR_TEMP`, `POWER_LIMIT_ESC_TEMP`.
 
 ### PowerAlert — `PowerAlert/`

--- a/controller/src/Power/Power.cpp
+++ b/controller/src/Power/Power.cpp
@@ -11,32 +11,21 @@ Power::Power() {
     power = 100;
     batteryPowerFloor = 100;
     activeLimitCauses_ = POWER_LIMIT_NONE;
-    outputPwm = (float)ESC_MIN_PWM;
-    lastTickMs = 0;
     startState = StartState::IDLE;
     startingBeganAt = 0;
     idleBeganAt = 0;
-    startingPwmCap = (float)ESC_MIN_PWM;
 }
 
 unsigned int Power::getPwm() {
     if (!throttle.isCalibrated()) {
-        resetRampLimiting();
-        return (unsigned int)outputPwm;
+        resetMotorState();
+        return ESC_MIN_PWM;
     }
-
-    unsigned long now = millis();
-
-    if (lastTickMs == 0) lastTickMs = now;
-
-    unsigned long dt = now - lastTickMs;
-    if (dt > 50) dt = 50;
-    lastTickMs = now;
 
     unsigned int powerLimit  = getPower();
     unsigned int throttleMin = throttle.getThrottlePinMin();
     unsigned int throttleMax = throttle.getThrottlePinMax();
-    unsigned int throttleRaw = throttle.getThrottleRaw();
+    unsigned int throttleRaw = throttle.isEngaged() ? throttle.getThrottleRaw() : throttleMin;
 
     unsigned int allowedMax = throttleMin + ((throttleMax - throttleMin) * powerLimit) / 100;
     unsigned int clampedRaw = constrain(throttleRaw, throttleMin, allowedMax);
@@ -54,6 +43,7 @@ unsigned int Power::getPwm() {
     bool throttleActive = (targetPwm > (float)(ESC_MIN_PWM + THROTTLE_DEADBAND_US));
 
     if (getBoardConfig().useSmoothStart) {
+        unsigned long now = millis();
 
         switch (startState) {
 
@@ -62,26 +52,21 @@ unsigned int Power::getPwm() {
                 startState = StartState::STARTING;
                 startingBeganAt = now;
             }
-            outputPwm = (float)ESC_MIN_PWM;
             return ESC_MIN_PWM;
 
         case StartState::STARTING: {
             if (!throttleActive) {
                 startState = StartState::IDLE;
-                outputPwm = (float)ESC_MIN_PWM;
                 return ESC_MIN_PWM;
             }
             float wakeupPwm = (float)ESC_MIN_PWM + (float)(ESC_MAX_PWM - ESC_MIN_PWM) * (float)XAG_WAKEUP_PWM_PERCENT / 100.0f;
             if (now - startingBeganAt >= XAG_MOTOR_REACTION_DELAY_MS) {
                 startState = StartState::RUNNING;
-                outputPwm = wakeupPwm;
-                // intentional: transition to RUNNING on same tick — [[fallthrough]] below
-            } else {
-                outputPwm = wakeupPwm;
-                return (unsigned int)outputPwm;
+                return (unsigned int)targetPwm;
             }
-            [[fallthrough]]; // intentional: after delay expires, execute RUNNING logic immediately
+            return (unsigned int)wakeupPwm;
         }
+
         case StartState::RUNNING:
             if (!throttleActive) {
                 if (idleBeganAt == 0) idleBeganAt = now;
@@ -89,43 +74,22 @@ unsigned int Power::getPwm() {
                 if (now - idleBeganAt >= MOTOR_STOP_TIME_MS) {
                     startState = StartState::IDLE;
                     idleBeganAt = 0;
-                    outputPwm = (float)ESC_MIN_PWM;
                     return ESC_MIN_PWM;
                 }
             } else {
                 idleBeganAt = 0;
             }
-
-            {
-                float delta  = targetPwm - outputPwm;
-                float maxUp   = THROTTLE_RAMP_UP_US_PER_MS   * (float)dt;
-                float maxDown = THROTTLE_RAMP_DOWN_US_PER_MS  * (float)dt;
-                if (delta > 0.0f)      outputPwm += min(delta,  maxUp);
-                else if (delta < 0.0f) outputPwm += max(delta, -maxDown);
-            }
-            outputPwm = constrain(outputPwm, (float)ESC_MIN_PWM, (float)ESC_MAX_PWM);
-            return (unsigned int)outputPwm;
+            return (unsigned int)targetPwm;
         }
     }
 
-    {
-        float delta  = targetPwm - outputPwm;
-        float maxUp   = THROTTLE_RAMP_UP_US_PER_MS   * (float)dt;
-        float maxDown = THROTTLE_RAMP_DOWN_US_PER_MS  * (float)dt;
-        if (delta > 0.0f)      outputPwm += min(delta,  maxUp);
-        else if (delta < 0.0f) outputPwm += max(delta, -maxDown);
-    }
-    outputPwm = constrain(outputPwm, (float)ESC_MIN_PWM, (float)ESC_MAX_PWM);
-    return (unsigned int)outputPwm;
+    return (unsigned int)targetPwm;
 }
 
-void Power::resetRampLimiting() {
-    outputPwm  = (float)ESC_MIN_PWM;
-    lastTickMs = 0;
+void Power::resetMotorState() {
     startState = StartState::IDLE;
     startingBeganAt = 0;
     idleBeganAt = 0;
-    startingPwmCap = (float)ESC_MIN_PWM;
 }
 
 unsigned int Power::getPower() {
@@ -212,5 +176,5 @@ unsigned int Power::calcEscTempLimit() {
 
 void Power::resetBatteryPowerFloor() {
     batteryPowerFloor = 100;
-    resetRampLimiting();
+    resetMotorState();
 }

--- a/controller/src/Power/Power.h
+++ b/controller/src/Power/Power.h
@@ -20,7 +20,7 @@ public:
     unsigned int getPower();
     uint8_t getActiveLimitCauses() const { return activeLimitCauses_; }
     void resetBatteryPowerFloor();
-    void resetRampLimiting();
+    void resetMotorState();
 
 private:
     enum class StartState {
@@ -33,13 +33,9 @@ private:
     unsigned int power;
     unsigned int batteryPowerFloor;
 
-    float outputPwm;
-    unsigned long lastTickMs;
-
     StartState startState;
     unsigned long startingBeganAt;
     unsigned long idleBeganAt;
-    float startingPwmCap;
 
     uint8_t activeLimitCauses_;
 

--- a/controller/src/Sensors/BatteryVoltageSensor.cpp
+++ b/controller/src/Sensors/BatteryVoltageSensor.cpp
@@ -2,12 +2,13 @@
 #include "../config.h"
 
 BatteryVoltageSensor::BatteryVoltageSensor(ReadFn readFn, float dividerRatio, float adcVoltageRef)
-    : readFn(readFn), dividerRatio(dividerRatio), adcVoltageRef(adcVoltageRef), voltageMilliVolts(0), lastRead(0) {
+    : readFn(readFn), dividerRatio(dividerRatio), adcVoltageRef(adcVoltageRef), voltageMilliVolts(0),
+      lastRead(0), emaVoltageMilliVolts(0.0f), emaInitialized(false) {
 }
 
 void BatteryVoltageSensor::handle() {
     unsigned long now = millis();
-    if (now - lastRead < 100) {
+    if (now - lastRead < READ_INTERVAL_MS) {
         return;
     }
     lastRead = now;
@@ -15,11 +16,7 @@ void BatteryVoltageSensor::handle() {
 }
 
 void BatteryVoltageSensor::readVoltage() {
-    int oversampledValue = 0;
-    for (int i = 0; i < oversampleCount; i++) {
-        oversampledValue += readFn();
-    }
-    int adcValue = oversampledValue / oversampleCount;
+    int adcValue = readFn();
 
     // Convert ADC reading to voltage at sensor pin
     // adcVoltageRef: 3.3V for ESP32 ADC, 4.096V for ADS1115 GAIN_ONE
@@ -31,5 +28,14 @@ void BatteryVoltageSensor::readVoltage() {
 
     // Convert to millivolts
     // Maximum expected: 60.0V, so 60.0 * 1000 = 60000 mV < 65535 (uint16_t max)
-    voltageMilliVolts = (uint16_t)(batteryVoltage * 1000.0 + 0.5);
+    float rawMilliVolts = (float)(batteryVoltage * 1000.0);
+
+    if (!emaInitialized) {
+        emaVoltageMilliVolts = rawMilliVolts;
+        emaInitialized = true;
+    } else {
+        emaVoltageMilliVolts += EMA_ALPHA * (rawMilliVolts - emaVoltageMilliVolts);
+    }
+
+    voltageMilliVolts = (uint16_t)(emaVoltageMilliVolts + 0.5f);
 }

--- a/controller/src/Sensors/BatteryVoltageSensor.h
+++ b/controller/src/Sensors/BatteryVoltageSensor.h
@@ -12,13 +12,16 @@ public:
     void setDividerRatio(float ratio) { dividerRatio = ratio; }
 
 private:
-    static const int oversampleCount = 10;
+    static constexpr unsigned long READ_INTERVAL_MS = 500;
+    static constexpr float EMA_ALPHA = 0.3f;
 
     ReadFn readFn;
     float dividerRatio;
     float adcVoltageRef;
     uint16_t voltageMilliVolts;
     unsigned long lastRead;
+    float emaVoltageMilliVolts;
+    bool emaInitialized;
 
     void readVoltage();
 };

--- a/controller/src/Throttle/Throttle.cpp
+++ b/controller/src/Throttle/Throttle.cpp
@@ -32,6 +32,7 @@ void Throttle::handle()
 
   lastThrottleRead = now;
   readThrottlePin();
+  engagement.update(pinValueFiltered, throttlePinMin, throttlePinMax);
 
   // Handle calibration if not yet calibrated
   if (!calibrated) {
@@ -50,6 +51,7 @@ void Throttle::resetCalibration()
   calibrationCountMax = 0;
   calibrationSumMin = 0;
   calibrationCountMin = 0;
+  engagement.reset();
 }
 
 void Throttle::handleCalibration(unsigned long now)

--- a/controller/src/Throttle/Throttle.h
+++ b/controller/src/Throttle/Throttle.h
@@ -22,8 +22,7 @@ class Throttle {
         unsigned int getCalibratingStep() { return calibratingStep; }
 
     private:
-        const static int samples = 30;
-        const static int oversample = 4; // Number of readings to average per sample
+        const static int samples = 8;
         const unsigned int calibrationTime = 3000; // 3 seconds for calibration
         const int calibrationThreshold = 2000; // Threshold for detecting throttle movement
 

--- a/controller/src/Throttle/Throttle.h
+++ b/controller/src/Throttle/Throttle.h
@@ -3,6 +3,7 @@
 
 #include "../Buzzer/Buzzer.h"
 #include "../config.h"
+#include "ThrottleEngagementLogic.h"
 
 class Throttle {
     public:
@@ -13,6 +14,7 @@ class Throttle {
         void setArmed();
         void setDisarmed();
         bool isCalibrated() { return calibrated; }
+        bool isEngaged() { return engagement.isEngaged(); }
 
         unsigned int getThrottlePercentage();
         unsigned int getThrottleRaw();
@@ -28,6 +30,7 @@ class Throttle {
 
         int pinValues[samples];
         int pinValueFiltered;
+        ThrottleEngagementLogic engagement;
         unsigned long lastThrottleRead;
 
         volatile bool throttleArmed;

--- a/controller/src/Throttle/ThrottleEngagementLogic.h
+++ b/controller/src/Throttle/ThrottleEngagementLogic.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// Pure throttle engage/release hysteresis logic — no Arduino deps, host-testable.
+//
+// Protects against Hall-sensor drift/noise at idle: the motor only engages once the
+// filtered reading clears ENGAGE_THRESHOLD_PERCENT of the calibrated range above
+// pinMin, and releases only after dropping below RELEASE_THRESHOLD_PERCENT (lower
+// than the engage threshold) to avoid chatter around the boundary.
+//
+// Calibration (throttlePinMin/throttlePinMax) runs on every boot and is not
+// persisted, so pinMin is always a fresh at-rest reading from just before the
+// engage threshold is evaluated — no separate arm-time re-zero is needed.
+class ThrottleEngagementLogic {
+public:
+    ThrottleEngagementLogic() : engaged_(false) {}
+
+    bool update(int filtered, int pinMin, int pinMax) {
+        int range = pinMax - pinMin;
+        if (range <= 0) {
+            engaged_ = false;
+            return engaged_;
+        }
+
+        int engageThreshold  = pinMin + (range * ENGAGE_THRESHOLD_PERCENT) / 100;
+        int releaseThreshold = pinMin + (range * RELEASE_THRESHOLD_PERCENT) / 100;
+
+        if (!engaged_ && filtered > engageThreshold) {
+            engaged_ = true;
+        } else if (engaged_ && filtered < releaseThreshold) {
+            engaged_ = false;
+        }
+
+        return engaged_;
+    }
+
+    bool isEngaged() const { return engaged_; }
+    void reset() { engaged_ = false; }
+
+private:
+    static const int ENGAGE_THRESHOLD_PERCENT  = 2;
+    static const int RELEASE_THRESHOLD_PERCENT = 1;
+
+    bool engaged_;
+};

--- a/controller/src/config.h
+++ b/controller/src/config.h
@@ -145,13 +145,11 @@ extern PowerAlert powerAlert;
 #define ESC_TEMP_MIN_VALID 0 // 0 millicelsius = 0.000°C - Minimum valid temperature reading
 #define ESC_TEMP_MAX_VALID 120000 // 120000 millicelsius = 120.000°C - Maximum valid temperature reading
 
-// ========== THROTTLE RAMP LIMITING ==========
-#define THROTTLE_RAMP_UP_US_PER_MS     1.0f
-#define THROTTLE_RAMP_DOWN_US_PER_MS   4.0f
+// ========== THROTTLE ENGAGE / MOTOR START TIMING ==========
 #define THROTTLE_DEADBAND_US           20
 #define MOTOR_STOP_TIME_MS             800
 
-// XAG motor (useSmoothStart): 1.5s reaction delay when stopped. Send 5% PWM (wake-up) during that time; after 1.5s, ramp from 5% to target.
+// XAG motor (useSmoothStart): 1.5s reaction delay when stopped. Send 5% PWM (wake-up) during that time; after 1.5s, jump directly to target.
 // Only used when useSmoothStart is true (XAG build).
 #define XAG_MOTOR_REACTION_DELAY_MS    1500
 #define XAG_WAKEUP_PWM_PERCENT        5

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -209,7 +209,7 @@ void handleEsc()
 {
   if (!throttle.isArmed())
   {
-    power.resetRampLimiting();
+    power.resetMotorState();
     esc.writeMicroseconds(ESC_MIN_PWM);
     return;
   }

--- a/controller/test/ThrottleEngagementLogicTest.cpp
+++ b/controller/test/ThrottleEngagementLogicTest.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <cassert>
+using namespace std;
+
+// Pull in the pure logic header (no Arduino deps)
+#include "../src/Throttle/ThrottleEngagementLogic.h"
+
+// pinMin=1000, pinMax=2000 -> range=1000, engage at 1000+2%=1020, release at 1000+1%=1010
+int main() {
+    // Below engage threshold at rest — stays disengaged
+    {
+        ThrottleEngagementLogic logic;
+        assert(!logic.update(1000, 1000, 2000));
+        assert(!logic.update(1010, 1000, 2000)); // exactly at release threshold, not above engage
+        cout << "PASS: stays disengaged below engage threshold\n";
+    }
+
+    // Crossing above engage threshold — engages
+    {
+        ThrottleEngagementLogic logic;
+        assert(logic.update(1021, 1000, 2000));
+        assert(logic.isEngaged());
+        cout << "PASS: engages just above threshold\n";
+    }
+
+    // Hysteresis: once engaged, stays engaged between release and engage thresholds
+    {
+        ThrottleEngagementLogic logic;
+        assert(logic.update(1021, 1000, 2000));  // engage
+        assert(logic.update(1015, 1000, 2000));  // between 1010 and 1020 — still engaged
+        cout << "PASS: hysteresis holds engagement mid-band\n";
+    }
+
+    // Dropping below release threshold — disengages
+    {
+        ThrottleEngagementLogic logic;
+        logic.update(1021, 1000, 2000);          // engage
+        assert(!logic.update(1005, 1000, 2000)); // below release threshold
+        cout << "PASS: releases below release threshold\n";
+    }
+
+    // Uncalibrated (zero range) — never engages regardless of reading
+    {
+        ThrottleEngagementLogic logic;
+        assert(!logic.update(5000, 1000, 1000));
+        cout << "PASS: never engages with zero calibration range\n";
+    }
+
+    // Full stick immediately — engages on the very first sample
+    {
+        ThrottleEngagementLogic logic;
+        assert(logic.update(2000, 1000, 2000));
+        cout << "PASS: engages immediately on full-stick input\n";
+    }
+
+    // Noise below engage threshold never triggers engagement
+    {
+        ThrottleEngagementLogic logic;
+        assert(!logic.update(1000, 1000, 2000));
+        assert(!logic.update(1015, 1000, 2000));
+        assert(!logic.update(1000, 1000, 2000));
+        assert(!logic.update(1015, 1000, 2000));
+        cout << "PASS: noise below engage threshold never engages\n";
+    }
+
+    // reset() forces disengagement (used when calibration restarts)
+    {
+        ThrottleEngagementLogic logic;
+        logic.update(2000, 1000, 2000); // engage
+        logic.reset();
+        assert(!logic.isEngaged());
+        cout << "PASS: reset() forces disengagement\n";
+    }
+
+    cout << "All ThrottleEngagementLogic tests passed!\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes reported ~1s dead time between fast throttle input and motor response on the tmotor build (and applies equally to Hobbywing/XAG). Root causes and field-telemetry analysis in `docs/superpowers/specs/2026-07-02-throttle-latency-reduction-design.md` (local, not committed).

- Shrink throttle moving-average filter from 30 to 8 samples (~145ms → ~35ms group delay)
- Remove the acceleration ramp limiter from `Power` entirely (all builds) — PWM now tracks mapped throttle position directly instead of slewing at a fixed µs/ms rate
- Add an explicit engage/release hysteresis gate (`ThrottleEngagementLogic`, host-tested) to replace the ramp's implicit noise protection: motor output stays at `ESC_MIN_PWM` until filtered throttle clears `throttlePinMin + 2%`, releases below `+1%`
- Reduce `BatteryVoltageSensor` from 10 blocking ADC reads every 100ms to 1 read every 500ms + EMA smoothing, cutting a recurring I2C stall on the main loop
- XAG's smooth-start wake-up (1.5s at 5% PWM) is preserved unchanged — only the ramp inside it is gone, it jumps straight to target after wake-up
- Update root and `controller/src` CLAUDE.md to reflect the new behavior

## Test plan

- [x] Host test `ThrottleEngagementLogicTest` — 8/8 passing
- [x] Build `lolin_c3_mini_hobbywing` — SUCCESS
- [x] Build `lolin_c3_mini_tmotor` — SUCCESS
- [x] Build `lolin_c3_mini_xag` — SUCCESS
- [x] Build `remote_throttle` — SUCCESS
- [ ] Bench test before flying: confirm no ghost-spin at rest, check full-stick current transient, verify wireless failsafe cuts instantly on link loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)